### PR TITLE
fixed folder path to saveTracksToFolder method

### DIFF
--- a/src/ofxTimeline.cpp
+++ b/src/ofxTimeline.cpp
@@ -240,6 +240,7 @@ void ofxTimeline::saveTracksToFolder(string folderPath){
 	if(!targetDirectory.exists()){
 		targetDirectory.create(true);
 	}
+    folderPath = ofFilePath::addTrailingSlash(folderPath);
 	for(int i = 0; i < pages.size(); i++){
         pages[i]->saveTracksToFolder(folderPath);
     }


### PR DESCRIPTION
Found a bug when trying to save out timeline settings. Think this fixed it though.
