### PR TITLE
fixed zoomer setup bug

### DIFF
--- a/src/ofxTimeline.cpp
+++ b/src/ofxTimeline.cpp
@@ -168,9 +168,7 @@ void ofxTimeline::setup(){
 	if(name == ""){
 	    setName("timeline" + ofToString(timelineNumber++));
 	}
-	else{
-		setupStandardElements();
-	}
+	setupStandardElements();
 
 }
 


### PR DESCRIPTION
The zoomer wasn't working in the develop branch.  I tracked it down to the fact that it's `setup()` method wasn't being called in `ofTimeline.setup()`. I think that this is the proper remedy, but there might be some use case I'm failing to see.
