### PR TITLE
Updates example to OF 0.8 standard. (project generator)

### DIFF
--- a/example-allTracks/Makefile
+++ b/example-allTracks/Makefile
@@ -1,0 +1,13 @@
+# Attempt to load a config.make file.
+# If none is found, project defaults in config.project.make will be used.
+ifneq ($(wildcard config.make),)
+	include config.make
+endif
+
+# make sure the the OF_ROOT location is defined
+ifndef OF_ROOT
+    OF_ROOT=../../..
+endif
+
+# call the project makefile!
+include $(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk

--- a/example-allTracks/Project.xcconfig
+++ b/example-allTracks/Project.xcconfig
@@ -5,5 +5,13 @@ OF_PATH = ../../..
 //THIS HAS ALL THE HEADER AND LIBS FOR OF CORE
 #include "../../../libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig"
 
-OTHER_LDFLAGS = $(OF_CORE_LIBS) 
+//ICONS - NEW IN 0072 
+ICON_NAME_DEBUG = icon-debug.icns
+ICON_NAME_RELEASE = icon.icns
+ICON_FILE_PATH = $(OF_PATH)/libs/openFrameworksCompiled/project/osx/
+
+//IF YOU WANT AN APP TO HAVE A CUSTOM ICON - PUT THEM IN YOUR DATA FOLDER AND CHANGE ICON_FILE_PATH to:
+//ICON_FILE_PATH = bin/data/
+
+OTHER_LDFLAGS = $(OF_CORE_LIBS) $(OF_CORE_FRAMEWORKS)
 HEADER_SEARCH_PATHS = $(OF_CORE_HEADERS)

--- a/example-allTracks/config.make
+++ b/example-allTracks/config.make
@@ -1,0 +1,142 @@
+################################################################################
+# CONFIGURE PROJECT MAKEFILE (optional)
+#   This file is where we make project specific configurations.
+################################################################################
+
+################################################################################
+# OF ROOT
+#   The location of your root openFrameworks installation
+#       (default) OF_ROOT = ../../.. 
+################################################################################
+# OF_ROOT = ../../..
+
+################################################################################
+# PROJECT ROOT
+#   The location of the project - a starting place for searching for files
+#       (default) PROJECT_ROOT = . (this directory)
+#    
+################################################################################
+# PROJECT_ROOT = .
+
+################################################################################
+# PROJECT SPECIFIC CHECKS
+#   This is a project defined section to create internal makefile flags to 
+#   conditionally enable or disable the addition of various features within 
+#   this makefile.  For instance, if you want to make changes based on whether
+#   GTK is installed, one might test that here and create a variable to check. 
+################################################################################
+# None
+
+################################################################################
+# PROJECT EXTERNAL SOURCE PATHS
+#   These are fully qualified paths that are not within the PROJECT_ROOT folder.
+#   Like source folders in the PROJECT_ROOT, these paths are subject to 
+#   exlclusion via the PROJECT_EXLCUSIONS list.
+#
+#     (default) PROJECT_EXTERNAL_SOURCE_PATHS = (blank) 
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_EXTERNAL_SOURCE_PATHS = 
+
+################################################################################
+# PROJECT EXCLUSIONS
+#   These makefiles assume that all folders in your current project directory 
+#   and any listed in the PROJECT_EXTERNAL_SOURCH_PATHS are are valid locations
+#   to look for source code. The any folders or files that match any of the 
+#   items in the PROJECT_EXCLUSIONS list below will be ignored.
+#
+#   Each item in the PROJECT_EXCLUSIONS list will be treated as a complete 
+#   string unless teh user adds a wildcard (%) operator to match subdirectories.
+#   GNU make only allows one wildcard for matching.  The second wildcard (%) is
+#   treated literally.
+#
+#      (default) PROJECT_EXCLUSIONS = (blank)
+#
+#		Will automatically exclude the following:
+#
+#			$(PROJECT_ROOT)/bin%
+#			$(PROJECT_ROOT)/obj%
+#			$(PROJECT_ROOT)/%.xcodeproj
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_EXCLUSIONS =
+
+################################################################################
+# PROJECT LINKER FLAGS
+#	These flags will be sent to the linker when compiling the executable.
+#
+#		(default) PROJECT_LDFLAGS = -Wl,-rpath=./libs
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+
+# Currently, shared libraries that are needed are copied to the 
+# $(PROJECT_ROOT)/bin/libs directory.  The following LDFLAGS tell the linker to
+# add a runtime path to search for those shared libraries, since they aren't 
+# incorporated directly into the final executable application binary.
+# TODO: should this be a default setting?
+# PROJECT_LDFLAGS=-Wl,-rpath=./libs
+
+################################################################################
+# PROJECT DEFINES
+#   Create a space-delimited list of DEFINES. The list will be converted into 
+#   CFLAGS with the "-D" flag later in the makefile.
+#
+#		(default) PROJECT_DEFINES = (blank)
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_DEFINES = 
+
+################################################################################
+# PROJECT CFLAGS
+#   This is a list of fully qualified CFLAGS required when compiling for this 
+#   project.  These CFLAGS will be used IN ADDITION TO the PLATFORM_CFLAGS 
+#   defined in your platform specific core configuration files. These flags are
+#   presented to the compiler BEFORE the PROJECT_OPTIMIZATION_CFLAGS below. 
+#
+#		(default) PROJECT_CFLAGS = (blank)
+#
+#   Note: Before adding PROJECT_CFLAGS, note that the PLATFORM_CFLAGS defined in 
+#   your platform specific configuration file will be applied by default and 
+#   further flags here may not be needed.
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_CFLAGS = 
+
+################################################################################
+# PROJECT OPTIMIZATION CFLAGS
+#   These are lists of CFLAGS that are target-specific.  While any flags could 
+#   be conditionally added, they are usually limited to optimization flags. 
+#   These flags are added BEFORE the PROJECT_CFLAGS.
+#
+#   PROJECT_OPTIMIZATION_CFLAGS_RELEASE flags are only applied to RELEASE targets.
+#
+#		(default) PROJECT_OPTIMIZATION_CFLAGS_RELEASE = (blank)
+#
+#   PROJECT_OPTIMIZATION_CFLAGS_DEBUG flags are only applied to DEBUG targets.
+#
+#		(default) PROJECT_OPTIMIZATION_CFLAGS_DEBUG = (blank)
+#
+#   Note: Before adding PROJECT_OPTIMIZATION_CFLAGS, please note that the 
+#   PLATFORM_OPTIMIZATION_CFLAGS defined in your platform specific configuration 
+#   file will be applied by default and further optimization flags here may not 
+#   be needed.
+#
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_OPTIMIZATION_CFLAGS_RELEASE = 
+# PROJECT_OPTIMIZATION_CFLAGS_DEBUG = 
+
+################################################################################
+# PROJECT COMPILERS
+#   Custom compilers can be set for CC and CXX
+#		(default) PROJECT_CXX = (blank)
+#		(default) PROJECT_CC = (blank)
+#   Note: Leave a leading space when adding list items with the += operator
+################################################################################
+# PROJECT_CXX = 
+# PROJECT_CC = 

--- a/example-allTracks/example-allTracks.xcodeproj/project.pbxproj
+++ b/example-allTracks/example-allTracks.xcodeproj/project.pbxproj
@@ -3,84 +3,68 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 42;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1479a06207a85dfdeca39f009ad023d0 /* ofxTLImageSequence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 236d66ae5b5c95729bfa6c29568f259b /* ofxTLImageSequence.cpp */; };
-		14ed851279c06f2bcf0bf27935d38ce3 /* ofxTLAudioTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = fe7dd2bcb46b69f0ddc85191ab090e70 /* ofxTLAudioTrack.cpp */; };
-		152eaecabd008d84af7f27f83f4389c4 /* ofxEasingLinear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9a4cfdcea412e8bcdaca9b26fb47846e /* ofxEasingLinear.cpp */; };
-		168c43f69af6a8042ea0b13f08dfe5ff /* easing_terms_of_use.html in Sources */ = {isa = PBXBuildFile; fileRef = 9aaef50558bbdbeb5260fc353bfd02d1 /* easing_terms_of_use.html */; };
-		27765d1bff26bd9a6186915f24dfd27c /* ofxEasingCirc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = a4973cef438c8931b5e03e0a3b5d05b5 /* ofxEasingCirc.cpp */; };
-		32fc7731c1ef7b87e491c93d78c84b88 /* ofxTween.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 497f252390399fcf843297da0271f914 /* ofxTween.cpp */; };
-		3a02cdf226d01ebb6533d47f0bb42c5a /* ofxTLTicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = e8e616bc8e15dee74a54901f444f74a3 /* ofxTLTicker.cpp */; };
-		3b32d3b612022d0c5b272bdd39e8a60f /* ofxTLVideoTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16644a54427c234fd75cb89d48524e02 /* ofxTLVideoTrack.cpp */; };
-		46be87fc2c481a1eb41aed2a8b97fe96 /* ofxTLCurves.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7f47d144dc8b3e5cd297eaf57dc4f889 /* ofxTLCurves.cpp */; };
-		49e60cc9bbcafb6eade107cc20884b9c /* ofxTLColorTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3d5a2b98580af9336c8c1886c7a2324d /* ofxTLColorTrack.cpp */; };
-		4df88daf2c820a78327000e7ac0925c5 /* ofxTLEmptyKeyframes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4fddcdd6e0eed2f5edd672855798f064 /* ofxTLEmptyKeyframes.cpp */; };
-		59eeacb88f062457ff86492c078803bd /* ofxEasingExpo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0f26d4edff0e9ea8cf68b694a2265e4f /* ofxEasingExpo.cpp */; };
-		5a4349e9754d6fa14c0f2a3a1abc30b6 /* tinyxmlparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = fc5da1c87211d4f6377da7199d8c5a1e /* tinyxmlparser.cpp */; };
-		5da2e0e8ecdb5b4e2908167d7b74de63 /* ofxHotKeys_impl_linux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4d892fbbb9e438c35b8c5ee430082e72 /* ofxHotKeys_impl_linux.cpp */; };
-		5e0dbde5736deb3a5886b3f1e3b4578d /* ofxEasingBack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7660dd2be873bad12e3a496d995f14e4 /* ofxEasingBack.cpp */; };
-		63b57ac5bf4ef088491e0317dbb2ecaa /* ofxXmlSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50df87d612c5aae17aafa6c02c6bc570 /* ofxXmlSettings.cpp */; };
-		6499b8489905bfe9067f8db81e6bbfdf /* ofxTimecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = d9882c87edc438b97f534f28d7e2bbc6 /* ofxTimecode.cpp */; };
-		65b24cd86db2ed8edd3385ac3e4a4783 /* ofxTLVideoThumb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = a208db91709b73833548f57d7336831e /* ofxTLVideoThumb.cpp */; };
-		6d7b53ed56654abbf2ff13b127236c33 /* ofxEasingQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = b9e1db01bd6701283fc879469dcb8bc0 /* ofxEasingQuad.cpp */; };
-		6e062274743f6716a9ad43959541a220 /* ofxEasingElastic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = a26c4a6254126c99f0a65354aa3cbcd0 /* ofxEasingElastic.cpp */; };
-		782c2b355cb6ebc83bdb95e0bd931001 /* kiss_fftr.c in Sources */ = {isa = PBXBuildFile; fileRef = b86c4bcf6618e3505813c304817a9b6f /* kiss_fftr.c */; };
-		7ac6376b15bcf4d368ec068f0ecce711 /* ofxTimeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 173c557b81a5be86d194eeb6d6250f91 /* ofxTimeline.cpp */; };
-		7d7ecd8dd8eb4244d7a87f40ba8c53cd /* ofxHotKeys_impl_mac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2506aa6a6ef4e116e23a1c24c5fbd57f /* ofxHotKeys_impl_mac.mm */; };
-		7e769097de6561633305b24c2ad560e7 /* ofxEasingQuint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = fb8a50f8a34037bcd5dc10d0c3441a16 /* ofxEasingQuint.cpp */; };
-		85a41526fdfa1a8cdaee81f79de999b7 /* ofxEasingQuart.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 882494db324414b7b31db11cc14948d9 /* ofxEasingQuart.cpp */; };
-		9119bfc53670a98106e367bbc1bd167a /* ofxMSATimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = b4ebe6922de4dcb97639b65f848e477b /* ofxMSATimer.cpp */; };
-		9266028e1aecbb027abf64d8cfab4b5f /* ofxEasing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26e160699149d8af609734a1b63d80e2 /* ofxEasing.cpp */; };
-		933a2227713c720ceff80fd967d0a8ee /* tinyxml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2b40eda85beb63e46785bc299a638898 /* tinyxml.cpp */; };
-		95e6e69db45e5f9e4f1c21e09d04b380 /* ofxTLImageTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3e8baad02914d140c0ced3d7a9533896 /* ofxTLImageTrack.cpp */; };
-		98126aa8f306f3ee0f5f37bed7056435 /* ofxTLEmptyTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32d83269769d4d7e74bf125b5842071d /* ofxTLEmptyTrack.cpp */; };
-		9d44dc88ef9e7991b4a09951e2e4769f /* tinyxmlerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 832bdc407620cdba568b713d2252c43c /* tinyxmlerror.cpp */; };
-		9d7bb9637658a8e9d507c66c47db010f /* ofxTLColors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = df90b9976feccfe157607af4463f9da0 /* ofxTLColors.cpp */; };
-		9e8ec2bf8bca13da057fa929463bbafb /* ofxTLSwitches.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5d23395ac4260312d47bb9588e732fd1 /* ofxTLSwitches.cpp */; };
-		BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
+		152EAECABD008D84AF7F27F8 /* ofxEasingLinear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9A4CFDCEA412E8BCDACA9B26 /* ofxEasingLinear.cpp */; };
+		168C43F69AF6A8042EA0B13F /* easing_terms_of_use.html in Sources */ = {isa = PBXBuildFile; fileRef = 9AAEF50558BBDBEB5260FC35 /* easing_terms_of_use.html */; };
+		27765D1BFF26BD9A6186915F /* ofxEasingCirc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4973CEF438C8931B5E03E0A /* ofxEasingCirc.cpp */; };
+		32FC7731C1EF7B87E491C93D /* ofxTween.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 497F252390399FCF843297DA /* ofxTween.cpp */; };
+		59EEACB88F062457FF86492C /* ofxEasingExpo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F26D4EDFF0E9EA8CF68B694 /* ofxEasingExpo.cpp */; };
+		5A4349E9754D6FA14C0F2A3A /* tinyxmlparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC5DA1C87211D4F6377DA719 /* tinyxmlparser.cpp */; };
+		5E0DBDE5736DEB3A5886B3F1 /* ofxEasingBack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7660DD2BE873BAD12E3A496D /* ofxEasingBack.cpp */; };
+		63B57AC5BF4EF088491E0317 /* ofxXmlSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50DF87D612C5AAE17AAFA6C0 /* ofxXmlSettings.cpp */; };
+		6499B8489905BFE9067F8DB8 /* ofxTimecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D9882C87EDC438B97F534F28 /* ofxTimecode.cpp */; };
+		6D7B53ED56654ABBF2FF13B1 /* ofxEasingQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B9E1DB01BD6701283FC87946 /* ofxEasingQuad.cpp */; };
+		6E062274743F6716A9AD4395 /* ofxEasingElastic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A26C4A6254126C99F0A65354 /* ofxEasingElastic.cpp */; };
+		7E769097DE6561633305B24C /* ofxEasingQuint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FB8A50F8A34037BCD5DC10D0 /* ofxEasingQuint.cpp */; };
+		85A041EF1AFCFB7F00819299 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85A041EE1AFCFB7F00819299 /* OpenAL.framework */; };
+		85A041F01AFCFC8500819299 /* libsndfile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 85F988A11AFCDE3200BA7587 /* libsndfile.a */; };
+		85A41526FDFA1A8CDAEE81F7 /* ofxEasingQuart.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 882494DB324414B7B31DB11C /* ofxEasingQuart.cpp */; };
+		85F988A81AFCDE3200BA7587 /* ofxHotKeys_impl_linux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988401AFCDE3200BA7587 /* ofxHotKeys_impl_linux.cpp */; };
+		85F988A91AFCDE3200BA7587 /* ofxHotKeys_impl_mac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 85F988411AFCDE3200BA7587 /* ofxHotKeys_impl_mac.mm */; };
+		85F988AA1AFCDE3200BA7587 /* ofxHotKeys_impl_win.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988421AFCDE3200BA7587 /* ofxHotKeys_impl_win.cpp */; };
+		85F988AB1AFCDE3200BA7587 /* ofxRemoveCocoaMenu.mm in Sources */ = {isa = PBXBuildFile; fileRef = 85F988441AFCDE3200BA7587 /* ofxRemoveCocoaMenu.mm */; };
+		85F988AC1AFCDE3200BA7587 /* ofxTimeline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988451AFCDE3200BA7587 /* ofxTimeline.cpp */; };
+		85F988AD1AFCDE3200BA7587 /* ofxTLAudioTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988471AFCDE3200BA7587 /* ofxTLAudioTrack.cpp */; };
+		85F988AE1AFCDE3200BA7587 /* ofxTLBangs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988491AFCDE3200BA7587 /* ofxTLBangs.cpp */; };
+		85F988AF1AFCDE3200BA7587 /* ofxTLCameraTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9884B1AFCDE3200BA7587 /* ofxTLCameraTrack.cpp */; };
+		85F988B01AFCDE3200BA7587 /* ofxTLColors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9884D1AFCDE3200BA7587 /* ofxTLColors.cpp */; };
+		85F988B11AFCDE3200BA7587 /* ofxTLColorTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9884F1AFCDE3200BA7587 /* ofxTLColorTrack.cpp */; };
+		85F988B21AFCDE3200BA7587 /* ofxTLCurves.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988511AFCDE3200BA7587 /* ofxTLCurves.cpp */; };
+		85F988B31AFCDE3200BA7587 /* ofxTLEmptyKeyframes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988531AFCDE3200BA7587 /* ofxTLEmptyKeyframes.cpp */; };
+		85F988B41AFCDE3200BA7587 /* ofxTLEmptyTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988551AFCDE3200BA7587 /* ofxTLEmptyTrack.cpp */; };
+		85F988B51AFCDE3200BA7587 /* ofxTLFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988581AFCDE3200BA7587 /* ofxTLFlags.cpp */; };
+		85F988B61AFCDE3200BA7587 /* ofxTLImageSequence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9885A1AFCDE3200BA7587 /* ofxTLImageSequence.cpp */; };
+		85F988B71AFCDE3200BA7587 /* ofxTLImageSequenceFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9885C1AFCDE3200BA7587 /* ofxTLImageSequenceFrame.cpp */; };
+		85F988B81AFCDE3200BA7587 /* ofxTLImageTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9885E1AFCDE3200BA7587 /* ofxTLImageTrack.cpp */; };
+		85F988B91AFCDE3200BA7587 /* ofxTLInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988601AFCDE3200BA7587 /* ofxTLInOut.cpp */; };
+		85F988BA1AFCDE3200BA7587 /* ofxTLKeyframes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988621AFCDE3200BA7587 /* ofxTLKeyframes.cpp */; };
+		85F988BB1AFCDE3200BA7587 /* ofxTLLFO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988641AFCDE3200BA7587 /* ofxTLLFO.cpp */; };
+		85F988BC1AFCDE3200BA7587 /* ofxTLPage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988661AFCDE3200BA7587 /* ofxTLPage.cpp */; };
+		85F988BD1AFCDE3200BA7587 /* ofxTLPageTabs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988681AFCDE3200BA7587 /* ofxTLPageTabs.cpp */; };
+		85F988BE1AFCDE3200BA7587 /* ofxTLSwitches.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9886A1AFCDE3200BA7587 /* ofxTLSwitches.cpp */; };
+		85F988BF1AFCDE3200BA7587 /* ofxTLTicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9886C1AFCDE3200BA7587 /* ofxTLTicker.cpp */; };
+		85F988C01AFCDE3200BA7587 /* ofxTLTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F9886E1AFCDE3200BA7587 /* ofxTLTrack.cpp */; };
+		85F988C11AFCDE3200BA7587 /* ofxTLTrackHeader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988701AFCDE3200BA7587 /* ofxTLTrackHeader.cpp */; };
+		85F988C21AFCDE3200BA7587 /* ofxTLVideoThumb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988721AFCDE3200BA7587 /* ofxTLVideoThumb.cpp */; };
+		85F988C31AFCDE3200BA7587 /* ofxTLVideoTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988741AFCDE3200BA7587 /* ofxTLVideoTrack.cpp */; };
+		85F988C41AFCDE3200BA7587 /* ofxTLZoomer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988761AFCDE3200BA7587 /* ofxTLZoomer.cpp */; };
+		85F988C51AFCDE3200BA7587 /* kiss_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 85F9887F1AFCDE3200BA7587 /* kiss_fft.c */; };
+		85F988C61AFCDE3200BA7587 /* kiss_fftr.c in Sources */ = {isa = PBXBuildFile; fileRef = 85F988801AFCDE3200BA7587 /* kiss_fftr.c */; };
+		85F988C71AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988831AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.cpp */; };
+		85F988D31AFCDE3300BA7587 /* ofxMSATimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85F988D11AFCDE3300BA7587 /* ofxMSATimer.cpp */; };
+		9266028E1AECBB027ABF64D8 /* ofxEasing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26E160699149D8AF609734A1 /* ofxEasing.cpp */; };
+		933A2227713C720CEFF80FD9 /* tinyxml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B40EDA85BEB63E46785BC29 /* tinyxml.cpp */; };
+		9D44DC88EF9E7991B4A09951 /* tinyxmlerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 832BDC407620CDBA568B713D /* tinyxmlerror.cpp */; };
 		E4328149138ABC9F0047C5CB /* openFrameworksDebug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4328148138ABC890047C5CB /* openFrameworksDebug.a */; };
-		E45BE97B0E8CC7DD009D7055 /* AGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9710E8CC7DD009D7055 /* AGL.framework */; };
-		E45BE97C0E8CC7DD009D7055 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9720E8CC7DD009D7055 /* ApplicationServices.framework */; };
-		E45BE97D0E8CC7DD009D7055 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9730E8CC7DD009D7055 /* AudioToolbox.framework */; };
-		E45BE97E0E8CC7DD009D7055 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9740E8CC7DD009D7055 /* Carbon.framework */; };
-		E45BE97F0E8CC7DD009D7055 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9750E8CC7DD009D7055 /* CoreAudio.framework */; };
-		E45BE9800E8CC7DD009D7055 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9760E8CC7DD009D7055 /* CoreFoundation.framework */; };
-		E45BE9810E8CC7DD009D7055 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9770E8CC7DD009D7055 /* CoreServices.framework */; };
-		E45BE9830E8CC7DD009D7055 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE9790E8CC7DD009D7055 /* OpenGL.framework */; };
-		E45BE9840E8CC7DD009D7055 /* QuickTime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E45BE97A0E8CC7DD009D7055 /* QuickTime.framework */; };
 		E4B69E200A3A1BDC003C02F2 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4B69E1D0A3A1BDC003C02F2 /* main.cpp */; };
-		E4B69E210A3A1BDC003C02F2 /* testApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4B69E1E0A3A1BDC003C02F2 /* testApp.cpp */; };
-		E4C2424710CC5A17004149E2 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C2424410CC5A17004149E2 /* AppKit.framework */; };
-		E4C2424810CC5A17004149E2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C2424510CC5A17004149E2 /* Cocoa.framework */; };
-		E4C2424910CC5A17004149E2 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C2424610CC5A17004149E2 /* IOKit.framework */; };
-		E4EB6799138ADC1D00A09F29 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBAB23BE13894E4700AA2426 /* GLUT.framework */; };
-		E7213A0016BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E72139FE16BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.cpp */; };
-		E778AED6163EF5AE003A40B1 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E778AED5163EF5AE003A40B1 /* OpenAL.framework */; };
-		E7E077E515D3B63C0020DFD4 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E077E415D3B63C0020DFD4 /* CoreVideo.framework */; };
-		E7E077E815D3B6510020DFD4 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7E077E715D3B6510020DFD4 /* QTKit.framework */; };
-		E7F985F815E0DEA3003869B5 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7F985F515E0DE99003869B5 /* Accelerate.framework */; };
-		b3baa90667d4b61631ba59627d616a39 /* ofxTLKeyframes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = e7379c3090a35247057d77fdade91aa0 /* ofxTLKeyframes.cpp */; };
-		bcfdfc3681cf3552bcdb819e675b5dce /* ofxTLPageTabs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 740abfc3dd8b605bb9c55d805231d094 /* ofxTLPageTabs.cpp */; };
-		c3bc382653a57ce71d4513f1eaba414b /* ofxTLFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = db375bbfeb77c75d4a4c3040d68281fb /* ofxTLFlags.cpp */; };
-		c7d250488914920c32f18f34136a2175 /* ofxTLPage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16bec8b1201859a26e3ffbc0b31ab24e /* ofxTLPage.cpp */; };
-		cf54b41ab5ff1af0e8677338f5f60395 /* ofxTLCameraTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0d65e6a2e0f22f72aa7670d7733a180e /* ofxTLCameraTrack.cpp */; };
-		d5f416a7f5798651d8370d5e93c0c797 /* kiss_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = d0fd108aa97d6409b427947c78757928 /* kiss_fft.c */; };
-		d7058ecb9868a269655092911f63df8c /* ofxTLInOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 215341b77a15aa8d842ed2f0c66df3e8 /* ofxTLInOut.cpp */; };
-		def58837140932f5996c61c2241ef66e /* ofxTLImageSequenceFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ccf76a8f53c203272707f428c7128157 /* ofxTLImageSequenceFrame.cpp */; };
-		e48c9224adc0eb481a762e226aaffadb /* ofxTLLFO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39833d65fff88a58c3cb8bdf62a80afb /* ofxTLLFO.cpp */; };
-		e6b21161287eea55fa4ea984beef0d72 /* ofxTLTrackHeader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ec09f970448422c45b6d1ebf77f17fde /* ofxTLTrackHeader.cpp */; };
-		e816d7d242d315fb53e23f5443df8700 /* ofxEasingCubic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34aa5dbaf88c8b757b46d40d80b9047b /* ofxEasingCubic.cpp */; };
-		e904ef309b050587cf73df2173a531a6 /* ofxHotKeys_impl_win.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 30666c151f907fce97822a8a38b276a6 /* ofxHotKeys_impl_win.cpp */; };
-		ead3ce0789481f975f351f39ee5137c4 /* ofxEasingBounce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00b7e2794a10f926df6305296b86a351 /* ofxEasingBounce.cpp */; };
-		ed77da7c8d99d9b1c9c240c836f5baf7 /* ofxTLZoomer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = c7a760ce8107cc5bb8ecbd37a5609bf9 /* ofxTLZoomer.cpp */; };
-		f4a426f97ee8f1a3ead2a8f00212b48a /* ofxTLTrack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = a5c128c6d62190c88cc9ab3b401d6e25 /* ofxTLTrack.cpp */; };
-		f6ca03081709fcbfdaef66765f9e376e /* ofxTextInputField.cpp in Sources */ = {isa = PBXBuildFile; fileRef = bcb6a6d9093ff11ee0d7d470a2de47c9 /* ofxTextInputField.cpp */; };
-		fb591e0c571e53b3ba5a60b84605de3d /* ofxTLBangs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 689fe82c6569027132ca3ee568a4ee1e /* ofxTLBangs.cpp */; };
-		fd525b9bc71cf001cac34c5a87c2672f /* ofxRemoveCocoaMenu.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8f610deb3752f20ff149bc096963cf80 /* ofxRemoveCocoaMenu.mm */; };
-		fe278f5f783581237ae8ecb25ea719bb /* ofxEasingSine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5faba58c3070af2f33e8c257343cea16 /* ofxEasingSine.cpp */; };
+		E4B69E210A3A1BDC003C02F2 /* ofApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4B69E1E0A3A1BDC003C02F2 /* ofApp.cpp */; };
+		E816D7D242D315FB53E23F54 /* ofxEasingCubic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 34AA5DBAF88C8B757B46D40D /* ofxEasingCubic.cpp */; };
+		EAD3CE0789481F975F351F39 /* ofxEasingBounce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B7E2794A10F926DF630529 /* ofxEasingBounce.cpp */; };
+		F6CA03081709FCBFDAEF6676 /* ofxTextInputField.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCB6A6D9093FF11EE0D7D470 /* ofxTextInputField.cpp */; };
+		FE278F5F783581237AE8ECB2 /* ofxEasingSine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5FABA58C3070AF2F33E8C257 /* ofxEasingSine.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,149 +91,142 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BBAB23CB13894F3D00AA2426 /* GLUT.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		00b7e2794a10f926df6305296b86a351 /* ofxEasingBounce.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingBounce.cpp; path = ../../ofxTween/src/Easings/ofxEasingBounce.cpp; sourceTree = SOURCE_ROOT; };
-		01dcc0911400f9acf5b65578af4ec8f9 /* ofxXmlSettings.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxXmlSettings.h; path = ../../ofxXmlSettings/src/ofxXmlSettings.h; sourceTree = SOURCE_ROOT; };
-		03dde55c47701116edeb18007fc4bf75 /* ofxMSATimer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxMSATimer.h; path = ../../ofxMSATimer/src/ofxMSATimer.h; sourceTree = SOURCE_ROOT; };
-		09cbd28db823fe305eb470eeba6c4f78 /* ofxTLImageSequence.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLImageSequence.h; path = ../src/ofxTLImageSequence.h; sourceTree = SOURCE_ROOT; };
-		0c578fcc784a6245c49aee60b6681712 /* alc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = alc.h; path = ../libs/sndfile/include/AL/alc.h; sourceTree = SOURCE_ROOT; };
-		0d63c00fb3a729e001961ab70e84fb9d /* efx-creative.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = "efx-creative.h"; path = "../libs/sndfile/include/AL/efx-creative.h"; sourceTree = SOURCE_ROOT; };
-		0d65e6a2e0f22f72aa7670d7733a180e /* ofxTLCameraTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLCameraTrack.cpp; path = ../src/ofxTLCameraTrack.cpp; sourceTree = SOURCE_ROOT; };
-		0f26d4edff0e9ea8cf68b694a2265e4f /* ofxEasingExpo.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingExpo.cpp; path = ../../ofxTween/src/Easings/ofxEasingExpo.cpp; sourceTree = SOURCE_ROOT; };
-		16644a54427c234fd75cb89d48524e02 /* ofxTLVideoTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLVideoTrack.cpp; path = ../src/ofxTLVideoTrack.cpp; sourceTree = SOURCE_ROOT; };
-		16bec8b1201859a26e3ffbc0b31ab24e /* ofxTLPage.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLPage.cpp; path = ../src/ofxTLPage.cpp; sourceTree = SOURCE_ROOT; };
-		173c557b81a5be86d194eeb6d6250f91 /* ofxTimeline.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTimeline.cpp; path = ../src/ofxTimeline.cpp; sourceTree = SOURCE_ROOT; };
-		1a433a24e8182dd578600bffe7ac6da5 /* ofxTLZoomer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLZoomer.h; path = ../src/ofxTLZoomer.h; sourceTree = SOURCE_ROOT; };
-		215341b77a15aa8d842ed2f0c66df3e8 /* ofxTLInOut.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLInOut.cpp; path = ../src/ofxTLInOut.cpp; sourceTree = SOURCE_ROOT; };
-		22ec628e5fa510d7034a99bb49ae8da8 /* ofRange.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofRange.h; path = ../../ofxRange/src/ofRange.h; sourceTree = SOURCE_ROOT; };
-		236d66ae5b5c95729bfa6c29568f259b /* ofxTLImageSequence.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLImageSequence.cpp; path = ../src/ofxTLImageSequence.cpp; sourceTree = SOURCE_ROOT; };
-		2506aa6a6ef4e116e23a1c24c5fbd57f /* ofxHotKeys_impl_mac.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 30; name = ofxHotKeys_impl_mac.mm; path = ../src/ofxHotKeys_impl_mac.mm; sourceTree = SOURCE_ROOT; };
-		26e160699149d8af609734a1b63d80e2 /* ofxEasing.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasing.cpp; path = ../../ofxTween/src/Easings/ofxEasing.cpp; sourceTree = SOURCE_ROOT; };
-		2a99d747f2315daf1fb4f247021e7445 /* ofxTLFlags.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLFlags.h; path = ../src/ofxTLFlags.h; sourceTree = SOURCE_ROOT; };
-		2af40c99324fbebe7bab30147fc27af8 /* ofxTLVideoThumb.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLVideoThumb.h; path = ../src/ofxTLVideoThumb.h; sourceTree = SOURCE_ROOT; };
-		2b40eda85beb63e46785bc299a638898 /* tinyxml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = tinyxml.cpp; path = ../../ofxXmlSettings/libs/tinyxml.cpp; sourceTree = SOURCE_ROOT; };
-		2f050e7223102a218b1fb7ecd05fc3f5 /* kiss_fft.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = kiss_fft.h; path = ../libs/kiss/include/kiss_fft.h; sourceTree = SOURCE_ROOT; };
-		30666c151f907fce97822a8a38b276a6 /* ofxHotKeys_impl_win.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxHotKeys_impl_win.cpp; path = ../src/ofxHotKeys_impl_win.cpp; sourceTree = SOURCE_ROOT; };
-		3241b8bdc0b27471f8ee25d5a3db58b2 /* ofxTLPageTabs.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLPageTabs.h; path = ../src/ofxTLPageTabs.h; sourceTree = SOURCE_ROOT; };
-		32d83269769d4d7e74bf125b5842071d /* ofxTLEmptyTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLEmptyTrack.cpp; path = ../src/ofxTLEmptyTrack.cpp; sourceTree = SOURCE_ROOT; };
-		34aa5dbaf88c8b757b46d40d80b9047b /* ofxEasingCubic.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingCubic.cpp; path = ../../ofxTween/src/Easings/ofxEasingCubic.cpp; sourceTree = SOURCE_ROOT; };
-		39833d65fff88a58c3cb8bdf62a80afb /* ofxTLLFO.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLLFO.cpp; path = ../src/ofxTLLFO.cpp; sourceTree = SOURCE_ROOT; };
-		3d0621ce540a64d8d27e0af7f83b3eb2 /* ofxTLTrackHeader.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLTrackHeader.h; path = ../src/ofxTLTrackHeader.h; sourceTree = SOURCE_ROOT; };
-		3d5a2b98580af9336c8c1886c7a2324d /* ofxTLColorTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLColorTrack.cpp; path = ../src/ofxTLColorTrack.cpp; sourceTree = SOURCE_ROOT; };
-		3dbb60625304a9174a9a9635f98e40a7 /* ofxTLImageTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLImageTrack.h; path = ../src/ofxTLImageTrack.h; sourceTree = SOURCE_ROOT; };
-		3dc6648a0468fbecb5e45b57040e9eb5 /* ofxTween.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTween.h; path = ../../ofxTween/src/ofxTween.h; sourceTree = SOURCE_ROOT; };
-		3e8baad02914d140c0ced3d7a9533896 /* ofxTLImageTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLImageTrack.cpp; path = ../src/ofxTLImageTrack.cpp; sourceTree = SOURCE_ROOT; };
-		410e5fe3eb7fe9cb2726d36d724fd561 /* ofxTLTicker.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLTicker.h; path = ../src/ofxTLTicker.h; sourceTree = SOURCE_ROOT; };
-		4162e24aefc4c866df24e11560269162 /* sndfile.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = sndfile.h; path = ../libs/sndfile/include/sndfile.h; sourceTree = SOURCE_ROOT; };
-		497f252390399fcf843297da0271f914 /* ofxTween.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTween.cpp; path = ../../ofxTween/src/ofxTween.cpp; sourceTree = SOURCE_ROOT; };
-		4b817954d44bdb7ede7da278e95facfa /* _kiss_fft_guts.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = _kiss_fft_guts.h; path = ../libs/kiss/src/_kiss_fft_guts.h; sourceTree = SOURCE_ROOT; };
-		4c0e055e4176057631087aa3938a7c76 /* ofxEasingQuart.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingQuart.h; path = ../../ofxTween/src/Easings/ofxEasingQuart.h; sourceTree = SOURCE_ROOT; };
-		4d892fbbb9e438c35b8c5ee430082e72 /* ofxHotKeys_impl_linux.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxHotKeys_impl_linux.cpp; path = ../src/ofxHotKeys_impl_linux.cpp; sourceTree = SOURCE_ROOT; };
-		4fddcdd6e0eed2f5edd672855798f064 /* ofxTLEmptyKeyframes.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLEmptyKeyframes.cpp; path = ../src/ofxTLEmptyKeyframes.cpp; sourceTree = SOURCE_ROOT; };
-		50511502e9cfd66a7bb161f2bfee7db5 /* ofxTLCurves.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLCurves.h; path = ../src/ofxTLCurves.h; sourceTree = SOURCE_ROOT; };
-		50df87d612c5aae17aafa6c02c6bc570 /* ofxXmlSettings.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxXmlSettings.cpp; path = ../../ofxXmlSettings/src/ofxXmlSettings.cpp; sourceTree = SOURCE_ROOT; };
-		53a47d9878535b9b1670047561971d02 /* ofxTLColorTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLColorTrack.h; path = ../src/ofxTLColorTrack.h; sourceTree = SOURCE_ROOT; };
-		54e92bcd121baa568ec9b4fb6198d262 /* ofxTLEmptyTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLEmptyTrack.h; path = ../src/ofxTLEmptyTrack.h; sourceTree = SOURCE_ROOT; };
-		56d0182470bf6d3d6de9541980e67f8b /* ofxTLEmptyKeyframes.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLEmptyKeyframes.h; path = ../src/ofxTLEmptyKeyframes.h; sourceTree = SOURCE_ROOT; };
-		5d23395ac4260312d47bb9588e732fd1 /* ofxTLSwitches.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLSwitches.cpp; path = ../src/ofxTLSwitches.cpp; sourceTree = SOURCE_ROOT; };
-		5e9e6513bec36148928518b774158396 /* ofxEasingQuint.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingQuint.h; path = ../../ofxTween/src/Easings/ofxEasingQuint.h; sourceTree = SOURCE_ROOT; };
-		5faba58c3070af2f33e8c257343cea16 /* ofxEasingSine.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingSine.cpp; path = ../../ofxTween/src/Easings/ofxEasingSine.cpp; sourceTree = SOURCE_ROOT; };
-		6146999aa0b432590d07eb521d43e191 /* ofxHotKeys.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxHotKeys.h; path = ../src/ofxHotKeys.h; sourceTree = SOURCE_ROOT; };
-		66c910bfbec609d16e3b249a8448466d /* ofxTLSwitches.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLSwitches.h; path = ../src/ofxTLSwitches.h; sourceTree = SOURCE_ROOT; };
-		689fe82c6569027132ca3ee568a4ee1e /* ofxTLBangs.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLBangs.cpp; path = ../src/ofxTLBangs.cpp; sourceTree = SOURCE_ROOT; };
-		68eb873762b550705aa7464c7dfffede /* ofxTLLFO.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLLFO.h; path = ../src/ofxTLLFO.h; sourceTree = SOURCE_ROOT; };
-		6bc7dd2c4e83a707848be258865dbb01 /* ofxTLAudioTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLAudioTrack.h; path = ../src/ofxTLAudioTrack.h; sourceTree = SOURCE_ROOT; };
-		740abfc3dd8b605bb9c55d805231d094 /* ofxTLPageTabs.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLPageTabs.cpp; path = ../src/ofxTLPageTabs.cpp; sourceTree = SOURCE_ROOT; };
-		7599804c6260ec1cd8d3567dc11aa06a /* ofxEasingLinear.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingLinear.h; path = ../../ofxTween/src/Easings/ofxEasingLinear.h; sourceTree = SOURCE_ROOT; };
-		7660dd2be873bad12e3a496d995f14e4 /* ofxEasingBack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingBack.cpp; path = ../../ofxTween/src/Easings/ofxEasingBack.cpp; sourceTree = SOURCE_ROOT; };
-		767479279ebac134d46e74e76dc9f79f /* ofxEasingExpo.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingExpo.h; path = ../../ofxTween/src/Easings/ofxEasingExpo.h; sourceTree = SOURCE_ROOT; };
-		7912619b786f0238d22ed5f3c10786f2 /* ofxEasingBack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingBack.h; path = ../../ofxTween/src/Easings/ofxEasingBack.h; sourceTree = SOURCE_ROOT; };
-		7f47d144dc8b3e5cd297eaf57dc4f889 /* ofxTLCurves.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLCurves.cpp; path = ../src/ofxTLCurves.cpp; sourceTree = SOURCE_ROOT; };
-		832bdc407620cdba568b713d2252c43c /* tinyxmlerror.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = tinyxmlerror.cpp; path = ../../ofxXmlSettings/libs/tinyxmlerror.cpp; sourceTree = SOURCE_ROOT; };
-		882494db324414b7b31db11cc14948d9 /* ofxEasingQuart.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingQuart.cpp; path = ../../ofxTween/src/Easings/ofxEasingQuart.cpp; sourceTree = SOURCE_ROOT; };
-		883c9e7fc087dbbc061aed5d10b268ef /* ofxTLInOut.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLInOut.h; path = ../src/ofxTLInOut.h; sourceTree = SOURCE_ROOT; };
-		8e52dc6b4ea21969c85b8e832936acc3 /* ofxTLVideoTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLVideoTrack.h; path = ../src/ofxTLVideoTrack.h; sourceTree = SOURCE_ROOT; };
-		8f610deb3752f20ff149bc096963cf80 /* ofxRemoveCocoaMenu.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 30; name = ofxRemoveCocoaMenu.mm; path = ../src/ofxRemoveCocoaMenu.mm; sourceTree = SOURCE_ROOT; };
-		95c5241b62f5d1f0fe6c067b5331bca8 /* ofxTimecode.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTimecode.h; path = ../../ofxTimecode/src/ofxTimecode.h; sourceTree = SOURCE_ROOT; };
-		96033bf9d1ef22715e6afdc3b189dbc8 /* ofxTLTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLTrack.h; path = ../src/ofxTLTrack.h; sourceTree = SOURCE_ROOT; };
-		9a2f1d6ae148cd25f6bea00506177bc5 /* ofxTimeline.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTimeline.h; path = ../src/ofxTimeline.h; sourceTree = SOURCE_ROOT; };
-		9a4cfdcea412e8bcdaca9b26fb47846e /* ofxEasingLinear.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingLinear.cpp; path = ../../ofxTween/src/Easings/ofxEasingLinear.cpp; sourceTree = SOURCE_ROOT; };
-		9aaef50558bbdbeb5260fc353bfd02d1 /* easing_terms_of_use.html */ = {isa = PBXFileReference; explicitFileType = file; fileEncoding = 30; name = easing_terms_of_use.html; path = ../../ofxTween/src/Easings/easing_terms_of_use.html; sourceTree = SOURCE_ROOT; };
-		9d86b2b57c2f171846dfeaf4c063c399 /* ofxTLBangs.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLBangs.h; path = ../src/ofxTLBangs.h; sourceTree = SOURCE_ROOT; };
-		BBAB23BE13894E4700AA2426 /* GLUT.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLUT.framework; path = ../../../libs/glut/lib/osx/GLUT.framework; sourceTree = "<group>"; };
+		00B7E2794A10F926DF630529 /* ofxEasingBounce.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingBounce.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingBounce.cpp; sourceTree = SOURCE_ROOT; };
+		01DCC0911400F9ACF5B65578 /* ofxXmlSettings.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxXmlSettings.h; path = ../../../addons/ofxXmlSettings/src/ofxXmlSettings.h; sourceTree = SOURCE_ROOT; };
+		0F26D4EDFF0E9EA8CF68B694 /* ofxEasingExpo.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingExpo.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingExpo.cpp; sourceTree = SOURCE_ROOT; };
+		22EC628E5FA510D7034A99BB /* ofRange.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofRange.h; path = ../../../addons/ofxRange/src/ofRange.h; sourceTree = SOURCE_ROOT; };
+		26E160699149D8AF609734A1 /* ofxEasing.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasing.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasing.cpp; sourceTree = SOURCE_ROOT; };
+		2B40EDA85BEB63E46785BC29 /* tinyxml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = tinyxml.cpp; path = ../../../addons/ofxXmlSettings/libs/tinyxml.cpp; sourceTree = SOURCE_ROOT; };
+		34AA5DBAF88C8B757B46D40D /* ofxEasingCubic.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingCubic.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingCubic.cpp; sourceTree = SOURCE_ROOT; };
+		3D5A874AE34061363E1C19B1 /* ofxTextInputFieldFontRenderer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextInputFieldFontRenderer.h; path = ../../../addons/ofxTextInputField/src/ofxTextInputFieldFontRenderer.h; sourceTree = SOURCE_ROOT; };
+		3DC6648A0468FBECB5E45B57 /* ofxTween.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTween.h; path = ../../../addons/ofxTween/src/ofxTween.h; sourceTree = SOURCE_ROOT; };
+		497F252390399FCF843297DA /* ofxTween.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTween.cpp; path = ../../../addons/ofxTween/src/ofxTween.cpp; sourceTree = SOURCE_ROOT; };
+		4C0E055E4176057631087AA3 /* ofxEasingQuart.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingQuart.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingQuart.h; sourceTree = SOURCE_ROOT; };
+		50DF87D612C5AAE17AAFA6C0 /* ofxXmlSettings.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxXmlSettings.cpp; path = ../../../addons/ofxXmlSettings/src/ofxXmlSettings.cpp; sourceTree = SOURCE_ROOT; };
+		5E9E6513BEC36148928518B7 /* ofxEasingQuint.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingQuint.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingQuint.h; sourceTree = SOURCE_ROOT; };
+		5FABA58C3070AF2F33E8C257 /* ofxEasingSine.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingSine.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingSine.cpp; sourceTree = SOURCE_ROOT; };
+		7599804C6260EC1CD8D3567D /* ofxEasingLinear.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingLinear.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingLinear.h; sourceTree = SOURCE_ROOT; };
+		7660DD2BE873BAD12E3A496D /* ofxEasingBack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingBack.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingBack.cpp; sourceTree = SOURCE_ROOT; };
+		767479279EBAC134D46E74E7 /* ofxEasingExpo.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingExpo.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingExpo.h; sourceTree = SOURCE_ROOT; };
+		7912619B786F0238D22ED5F3 /* ofxEasingBack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingBack.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingBack.h; sourceTree = SOURCE_ROOT; };
+		832BDC407620CDBA568B713D /* tinyxmlerror.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = tinyxmlerror.cpp; path = ../../../addons/ofxXmlSettings/libs/tinyxmlerror.cpp; sourceTree = SOURCE_ROOT; };
+		85A041EE1AFCFB7F00819299 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
+		85F9883F1AFCDE3200BA7587 /* ofxHotKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxHotKeys.h; sourceTree = "<group>"; };
+		85F988401AFCDE3200BA7587 /* ofxHotKeys_impl_linux.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxHotKeys_impl_linux.cpp; sourceTree = "<group>"; };
+		85F988411AFCDE3200BA7587 /* ofxHotKeys_impl_mac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxHotKeys_impl_mac.mm; sourceTree = "<group>"; };
+		85F988421AFCDE3200BA7587 /* ofxHotKeys_impl_win.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxHotKeys_impl_win.cpp; sourceTree = "<group>"; };
+		85F988431AFCDE3200BA7587 /* ofxRemoveCocoaMenu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxRemoveCocoaMenu.h; sourceTree = "<group>"; };
+		85F988441AFCDE3200BA7587 /* ofxRemoveCocoaMenu.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxRemoveCocoaMenu.mm; sourceTree = "<group>"; };
+		85F988451AFCDE3200BA7587 /* ofxTimeline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTimeline.cpp; sourceTree = "<group>"; };
+		85F988461AFCDE3200BA7587 /* ofxTimeline.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTimeline.h; sourceTree = "<group>"; };
+		85F988471AFCDE3200BA7587 /* ofxTLAudioTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLAudioTrack.cpp; sourceTree = "<group>"; };
+		85F988481AFCDE3200BA7587 /* ofxTLAudioTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLAudioTrack.h; sourceTree = "<group>"; };
+		85F988491AFCDE3200BA7587 /* ofxTLBangs.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLBangs.cpp; sourceTree = "<group>"; };
+		85F9884A1AFCDE3200BA7587 /* ofxTLBangs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLBangs.h; sourceTree = "<group>"; };
+		85F9884B1AFCDE3200BA7587 /* ofxTLCameraTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLCameraTrack.cpp; sourceTree = "<group>"; };
+		85F9884C1AFCDE3200BA7587 /* ofxTLCameraTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLCameraTrack.h; sourceTree = "<group>"; };
+		85F9884D1AFCDE3200BA7587 /* ofxTLColors.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLColors.cpp; sourceTree = "<group>"; };
+		85F9884E1AFCDE3200BA7587 /* ofxTLColors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLColors.h; sourceTree = "<group>"; };
+		85F9884F1AFCDE3200BA7587 /* ofxTLColorTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLColorTrack.cpp; sourceTree = "<group>"; };
+		85F988501AFCDE3200BA7587 /* ofxTLColorTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLColorTrack.h; sourceTree = "<group>"; };
+		85F988511AFCDE3200BA7587 /* ofxTLCurves.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLCurves.cpp; sourceTree = "<group>"; };
+		85F988521AFCDE3200BA7587 /* ofxTLCurves.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLCurves.h; sourceTree = "<group>"; };
+		85F988531AFCDE3200BA7587 /* ofxTLEmptyKeyframes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLEmptyKeyframes.cpp; sourceTree = "<group>"; };
+		85F988541AFCDE3200BA7587 /* ofxTLEmptyKeyframes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLEmptyKeyframes.h; sourceTree = "<group>"; };
+		85F988551AFCDE3200BA7587 /* ofxTLEmptyTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLEmptyTrack.cpp; sourceTree = "<group>"; };
+		85F988561AFCDE3200BA7587 /* ofxTLEmptyTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLEmptyTrack.h; sourceTree = "<group>"; };
+		85F988571AFCDE3200BA7587 /* ofxTLEvents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLEvents.h; sourceTree = "<group>"; };
+		85F988581AFCDE3200BA7587 /* ofxTLFlags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLFlags.cpp; sourceTree = "<group>"; };
+		85F988591AFCDE3200BA7587 /* ofxTLFlags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLFlags.h; sourceTree = "<group>"; };
+		85F9885A1AFCDE3200BA7587 /* ofxTLImageSequence.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLImageSequence.cpp; sourceTree = "<group>"; };
+		85F9885B1AFCDE3200BA7587 /* ofxTLImageSequence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLImageSequence.h; sourceTree = "<group>"; };
+		85F9885C1AFCDE3200BA7587 /* ofxTLImageSequenceFrame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLImageSequenceFrame.cpp; sourceTree = "<group>"; };
+		85F9885D1AFCDE3200BA7587 /* ofxTLImageSequenceFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLImageSequenceFrame.h; sourceTree = "<group>"; };
+		85F9885E1AFCDE3200BA7587 /* ofxTLImageTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLImageTrack.cpp; sourceTree = "<group>"; };
+		85F9885F1AFCDE3200BA7587 /* ofxTLImageTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLImageTrack.h; sourceTree = "<group>"; };
+		85F988601AFCDE3200BA7587 /* ofxTLInOut.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLInOut.cpp; sourceTree = "<group>"; };
+		85F988611AFCDE3200BA7587 /* ofxTLInOut.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLInOut.h; sourceTree = "<group>"; };
+		85F988621AFCDE3200BA7587 /* ofxTLKeyframes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLKeyframes.cpp; sourceTree = "<group>"; };
+		85F988631AFCDE3200BA7587 /* ofxTLKeyframes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLKeyframes.h; sourceTree = "<group>"; };
+		85F988641AFCDE3200BA7587 /* ofxTLLFO.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLLFO.cpp; sourceTree = "<group>"; };
+		85F988651AFCDE3200BA7587 /* ofxTLLFO.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLLFO.h; sourceTree = "<group>"; };
+		85F988661AFCDE3200BA7587 /* ofxTLPage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLPage.cpp; sourceTree = "<group>"; };
+		85F988671AFCDE3200BA7587 /* ofxTLPage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLPage.h; sourceTree = "<group>"; };
+		85F988681AFCDE3200BA7587 /* ofxTLPageTabs.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLPageTabs.cpp; sourceTree = "<group>"; };
+		85F988691AFCDE3200BA7587 /* ofxTLPageTabs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLPageTabs.h; sourceTree = "<group>"; };
+		85F9886A1AFCDE3200BA7587 /* ofxTLSwitches.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLSwitches.cpp; sourceTree = "<group>"; };
+		85F9886B1AFCDE3200BA7587 /* ofxTLSwitches.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLSwitches.h; sourceTree = "<group>"; };
+		85F9886C1AFCDE3200BA7587 /* ofxTLTicker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLTicker.cpp; sourceTree = "<group>"; };
+		85F9886D1AFCDE3200BA7587 /* ofxTLTicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLTicker.h; sourceTree = "<group>"; };
+		85F9886E1AFCDE3200BA7587 /* ofxTLTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLTrack.cpp; sourceTree = "<group>"; };
+		85F9886F1AFCDE3200BA7587 /* ofxTLTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLTrack.h; sourceTree = "<group>"; };
+		85F988701AFCDE3200BA7587 /* ofxTLTrackHeader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLTrackHeader.cpp; sourceTree = "<group>"; };
+		85F988711AFCDE3200BA7587 /* ofxTLTrackHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLTrackHeader.h; sourceTree = "<group>"; };
+		85F988721AFCDE3200BA7587 /* ofxTLVideoThumb.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLVideoThumb.cpp; sourceTree = "<group>"; };
+		85F988731AFCDE3200BA7587 /* ofxTLVideoThumb.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLVideoThumb.h; sourceTree = "<group>"; };
+		85F988741AFCDE3200BA7587 /* ofxTLVideoTrack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLVideoTrack.cpp; sourceTree = "<group>"; };
+		85F988751AFCDE3200BA7587 /* ofxTLVideoTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLVideoTrack.h; sourceTree = "<group>"; };
+		85F988761AFCDE3200BA7587 /* ofxTLZoomer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTLZoomer.cpp; sourceTree = "<group>"; };
+		85F988771AFCDE3200BA7587 /* ofxTLZoomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxTLZoomer.h; sourceTree = "<group>"; };
+		85F9887B1AFCDE3200BA7587 /* kiss_fft.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = kiss_fft.h; sourceTree = "<group>"; };
+		85F9887C1AFCDE3200BA7587 /* kiss_fftr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = kiss_fftr.h; sourceTree = "<group>"; };
+		85F9887E1AFCDE3200BA7587 /* _kiss_fft_guts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _kiss_fft_guts.h; sourceTree = "<group>"; };
+		85F9887F1AFCDE3200BA7587 /* kiss_fft.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = kiss_fft.c; sourceTree = "<group>"; };
+		85F988801AFCDE3200BA7587 /* kiss_fftr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = kiss_fftr.c; sourceTree = "<group>"; };
+		85F988831AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofOpenALSoundPlayer_TimelineAdditions.cpp; sourceTree = "<group>"; };
+		85F988841AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofOpenALSoundPlayer_TimelineAdditions.h; sourceTree = "<group>"; };
+		85F988881AFCDE3200BA7587 /* al.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = al.h; sourceTree = "<group>"; };
+		85F988891AFCDE3200BA7587 /* alc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = alc.h; sourceTree = "<group>"; };
+		85F9888A1AFCDE3200BA7587 /* efx-creative.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "efx-creative.h"; sourceTree = "<group>"; };
+		85F9888B1AFCDE3200BA7587 /* EFX-Util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EFX-Util.h"; sourceTree = "<group>"; };
+		85F9888C1AFCDE3200BA7587 /* efx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = efx.h; sourceTree = "<group>"; };
+		85F9888D1AFCDE3200BA7587 /* xram.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xram.h; sourceTree = "<group>"; };
+		85F988911AFCDE3200BA7587 /* EFX-Util.lib */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "EFX-Util.lib"; sourceTree = "<group>"; };
+		85F988931AFCDE3200BA7587 /* EFX-Util.lib */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "EFX-Util.lib"; sourceTree = "<group>"; };
+		85F988941AFCDE3200BA7587 /* OpenAL32.lib */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = OpenAL32.lib; sourceTree = "<group>"; };
+		85F988971AFCDE3200BA7587 /* EFX-Util.lib */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "EFX-Util.lib"; sourceTree = "<group>"; };
+		85F988991AFCDE3200BA7587 /* EFX-Util.lib */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "EFX-Util.lib"; sourceTree = "<group>"; };
+		85F9889A1AFCDE3200BA7587 /* OpenAL32.lib */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = OpenAL32.lib; sourceTree = "<group>"; };
+		85F9889D1AFCDE3200BA7587 /* sndfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sndfile.h; sourceTree = "<group>"; };
+		85F9889E1AFCDE3200BA7587 /* sndfile.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = sndfile.hh; sourceTree = "<group>"; };
+		85F988A11AFCDE3200BA7587 /* libsndfile.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libsndfile.a; sourceTree = "<group>"; };
+		85F988A71AFCDE3200BA7587 /* libsndfile-1.dll */ = {isa = PBXFileReference; lastKnownFileType = file; path = "libsndfile-1.dll"; sourceTree = "<group>"; };
+		85F988D11AFCDE3300BA7587 /* ofxMSATimer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ofxMSATimer.cpp; sourceTree = "<group>"; };
+		85F988D21AFCDE3300BA7587 /* ofxMSATimer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxMSATimer.h; sourceTree = "<group>"; };
+		882494DB324414B7B31DB11C /* ofxEasingQuart.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingQuart.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingQuart.cpp; sourceTree = SOURCE_ROOT; };
+		95C5241B62F5D1F0FE6C067B /* ofxTimecode.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTimecode.h; path = ../../../addons/ofxTimecode/src/ofxTimecode.h; sourceTree = SOURCE_ROOT; };
+		9A4CFDCEA412E8BCDACA9B26 /* ofxEasingLinear.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingLinear.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingLinear.cpp; sourceTree = SOURCE_ROOT; };
+		9AAEF50558BBDBEB5260FC35 /* easing_terms_of_use.html */ = {isa = PBXFileReference; explicitFileType = file; fileEncoding = 30; name = easing_terms_of_use.html; path = ../../../addons/ofxTween/src/Easings/easing_terms_of_use.html; sourceTree = SOURCE_ROOT; };
+		A26C4A6254126C99F0A65354 /* ofxEasingElastic.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingElastic.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingElastic.cpp; sourceTree = SOURCE_ROOT; };
+		A4973CEF438C8931B5E03E0A /* ofxEasingCirc.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingCirc.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingCirc.cpp; sourceTree = SOURCE_ROOT; };
+		A9FE46C20E767B29C5997AD3 /* ofxEasingBounce.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingBounce.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingBounce.h; sourceTree = SOURCE_ROOT; };
+		AC5DDD8BBD12E8E173E4AE81 /* ofxTextInputField.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextInputField.h; path = ../../../addons/ofxTextInputField/src/ofxTextInputField.h; sourceTree = SOURCE_ROOT; };
+		AF17EB492DB2858A0EBD94CD /* ofxEasingCirc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingCirc.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingCirc.h; sourceTree = SOURCE_ROOT; };
+		B07C508E7717E6C892502ADF /* ofxEasingQuad.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingQuad.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingQuad.h; sourceTree = SOURCE_ROOT; };
+		B21E7E5F548EEA92F368040B /* tinyxml.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = tinyxml.h; path = ../../../addons/ofxXmlSettings/libs/tinyxml.h; sourceTree = SOURCE_ROOT; };
+		B788152C3FE538E700D063C7 /* ofxEasingCubic.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingCubic.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingCubic.h; sourceTree = SOURCE_ROOT; };
+		B9E1DB01BD6701283FC87946 /* ofxEasingQuad.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingQuad.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingQuad.cpp; sourceTree = SOURCE_ROOT; };
+		BCB6A6D9093FF11EE0D7D470 /* ofxTextInputField.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTextInputField.cpp; path = ../../../addons/ofxTextInputField/src/ofxTextInputField.cpp; sourceTree = SOURCE_ROOT; };
+		D9882C87EDC438B97F534F28 /* ofxTimecode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTimecode.cpp; path = ../../../addons/ofxTimecode/src/ofxTimecode.cpp; sourceTree = SOURCE_ROOT; };
+		DD476420FBC881796F865BB5 /* ofxEasingSine.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingSine.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingSine.h; sourceTree = SOURCE_ROOT; };
 		E4328143138ABC890047C5CB /* openFrameworksLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = openFrameworksLib.xcodeproj; path = ../../../libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj; sourceTree = SOURCE_ROOT; };
-		E45BE9710E8CC7DD009D7055 /* AGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AGL.framework; path = /System/Library/Frameworks/AGL.framework; sourceTree = "<absolute>"; };
-		E45BE9720E8CC7DD009D7055 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = /System/Library/Frameworks/ApplicationServices.framework; sourceTree = "<absolute>"; };
-		E45BE9730E8CC7DD009D7055 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = /System/Library/Frameworks/AudioToolbox.framework; sourceTree = "<absolute>"; };
-		E45BE9740E8CC7DD009D7055 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = /System/Library/Frameworks/Carbon.framework; sourceTree = "<absolute>"; };
-		E45BE9750E8CC7DD009D7055 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = /System/Library/Frameworks/CoreAudio.framework; sourceTree = "<absolute>"; };
-		E45BE9760E8CC7DD009D7055 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
-		E45BE9770E8CC7DD009D7055 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = /System/Library/Frameworks/CoreServices.framework; sourceTree = "<absolute>"; };
-		E45BE9790E8CC7DD009D7055 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
-		E45BE97A0E8CC7DD009D7055 /* QuickTime.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickTime.framework; path = /System/Library/Frameworks/QuickTime.framework; sourceTree = "<absolute>"; };
 		E4B69B5B0A3A1756003C02F2 /* example-allTracksDebug.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-allTracksDebug.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4B69E1D0A3A1BDC003C02F2 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = src/main.cpp; sourceTree = SOURCE_ROOT; };
-		E4B69E1E0A3A1BDC003C02F2 /* testApp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = testApp.cpp; path = src/testApp.cpp; sourceTree = SOURCE_ROOT; };
-		E4B69E1F0A3A1BDC003C02F2 /* testApp.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = testApp.h; path = src/testApp.h; sourceTree = SOURCE_ROOT; };
+		E4B69E1E0A3A1BDC003C02F2 /* ofApp.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofApp.cpp; path = src/ofApp.cpp; sourceTree = SOURCE_ROOT; };
+		E4B69E1F0A3A1BDC003C02F2 /* ofApp.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ofApp.h; path = src/ofApp.h; sourceTree = SOURCE_ROOT; };
 		E4B6FCAD0C3E899E008CF71C /* openFrameworks-Info.plist */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.plist.xml; path = "openFrameworks-Info.plist"; sourceTree = "<group>"; };
-		E4C2424410CC5A17004149E2 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
-		E4C2424510CC5A17004149E2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
-		E4C2424610CC5A17004149E2 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = /System/Library/Frameworks/IOKit.framework; sourceTree = "<absolute>"; };
 		E4EB691F138AFCF100A09F29 /* CoreOF.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = CoreOF.xcconfig; path = ../../../libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig; sourceTree = SOURCE_ROOT; };
 		E4EB6923138AFD0F00A09F29 /* Project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
-		E72139FE16BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofOpenALSoundPlayer_TimelineAdditions.cpp; sourceTree = "<group>"; };
-		E72139FF16BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofOpenALSoundPlayer_TimelineAdditions.h; sourceTree = "<group>"; };
-		E778AED5163EF5AE003A40B1 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
-		E7E077E415D3B63C0020DFD4 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
-		E7E077E715D3B6510020DFD4 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
-		E7F985F515E0DE99003869B5 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = /System/Library/Frameworks/Accelerate.framework; sourceTree = "<absolute>"; };
-		a208db91709b73833548f57d7336831e /* ofxTLVideoThumb.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLVideoThumb.cpp; path = ../src/ofxTLVideoThumb.cpp; sourceTree = SOURCE_ROOT; };
-		a26c4a6254126c99f0a65354aa3cbcd0 /* ofxEasingElastic.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingElastic.cpp; path = ../../ofxTween/src/Easings/ofxEasingElastic.cpp; sourceTree = SOURCE_ROOT; };
-		a365e230090b71900f9a7987aa6fccec /* ofxTLEvents.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLEvents.h; path = ../src/ofxTLEvents.h; sourceTree = SOURCE_ROOT; };
-		a4973cef438c8931b5e03e0a3b5d05b5 /* ofxEasingCirc.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingCirc.cpp; path = ../../ofxTween/src/Easings/ofxEasingCirc.cpp; sourceTree = SOURCE_ROOT; };
-		a5c128c6d62190c88cc9ab3b401d6e25 /* ofxTLTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLTrack.cpp; path = ../src/ofxTLTrack.cpp; sourceTree = SOURCE_ROOT; };
-		a9fe46c20e767b29c5997ad3a88b9f7b /* ofxEasingBounce.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingBounce.h; path = ../../ofxTween/src/Easings/ofxEasingBounce.h; sourceTree = SOURCE_ROOT; };
-		ac5ddd8bbd12e8e173e4ae81a6b924bc /* ofxTextInputField.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTextInputField.h; path = ../../ofxTextInputField/src/ofxTextInputField.h; sourceTree = SOURCE_ROOT; };
-		af17eb492db2858a0ebd94cd64092fb9 /* ofxEasingCirc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingCirc.h; path = ../../ofxTween/src/Easings/ofxEasingCirc.h; sourceTree = SOURCE_ROOT; };
-		afcc811df430141d32bab3ebf9ba8734 /* ofxTLColors.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLColors.h; path = ../src/ofxTLColors.h; sourceTree = SOURCE_ROOT; };
-		b07c508e7717e6c892502adf5fddc285 /* ofxEasingQuad.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingQuad.h; path = ../../ofxTween/src/Easings/ofxEasingQuad.h; sourceTree = SOURCE_ROOT; };
-		b21e7e5f548eea92f368040bb1aa2f69 /* tinyxml.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = tinyxml.h; path = ../../ofxXmlSettings/libs/tinyxml.h; sourceTree = SOURCE_ROOT; };
-		b4ebe6922de4dcb97639b65f848e477b /* ofxMSATimer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxMSATimer.cpp; path = ../../ofxMSATimer/src/ofxMSATimer.cpp; sourceTree = SOURCE_ROOT; };
-		b788152c3fe538e700d063c7d17da903 /* ofxEasingCubic.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingCubic.h; path = ../../ofxTween/src/Easings/ofxEasingCubic.h; sourceTree = SOURCE_ROOT; };
-		b7886c7b71ddb1e4091232870f09bb9e /* efx.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = efx.h; path = ../libs/sndfile/include/AL/efx.h; sourceTree = SOURCE_ROOT; };
-		b86c4bcf6618e3505813c304817a9b6f /* kiss_fftr.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 30; name = kiss_fftr.c; path = ../libs/kiss/src/kiss_fftr.c; sourceTree = SOURCE_ROOT; };
-		b9e1db01bd6701283fc879469dcb8bc0 /* ofxEasingQuad.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingQuad.cpp; path = ../../ofxTween/src/Easings/ofxEasingQuad.cpp; sourceTree = SOURCE_ROOT; };
-		b9fd7617cf5f462774962af9384ef0ac /* ofxTLKeyframes.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLKeyframes.h; path = ../src/ofxTLKeyframes.h; sourceTree = SOURCE_ROOT; };
-		ba109f25bb170b74a96b155fe64e5f9b /* alext.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = alext.h; path = ../libs/sndfile/include/AL/alext.h; sourceTree = SOURCE_ROOT; };
-		bc6bde994c25a3b82b30f694893b581f /* ofxTLPage.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLPage.h; path = ../src/ofxTLPage.h; sourceTree = SOURCE_ROOT; };
-		bcb6a6d9093ff11ee0d7d470a2de47c9 /* ofxTextInputField.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTextInputField.cpp; path = ../../ofxTextInputField/src/ofxTextInputField.cpp; sourceTree = SOURCE_ROOT; };
-		bfee9391f78307b42aa09c9afad043a8 /* kiss_fftr.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = kiss_fftr.h; path = ../libs/kiss/include/kiss_fftr.h; sourceTree = SOURCE_ROOT; };
-		c5b9174723940db207e7ab82b583bc7d /* al.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = al.h; path = ../libs/sndfile/include/AL/al.h; sourceTree = SOURCE_ROOT; };
-		c7a760ce8107cc5bb8ecbd37a5609bf9 /* ofxTLZoomer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLZoomer.cpp; path = ../src/ofxTLZoomer.cpp; sourceTree = SOURCE_ROOT; };
-		ccf76a8f53c203272707f428c7128157 /* ofxTLImageSequenceFrame.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLImageSequenceFrame.cpp; path = ../src/ofxTLImageSequenceFrame.cpp; sourceTree = SOURCE_ROOT; };
-		d0fd108aa97d6409b427947c78757928 /* kiss_fft.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.c; fileEncoding = 30; name = kiss_fft.c; path = ../libs/kiss/src/kiss_fft.c; sourceTree = SOURCE_ROOT; };
-		d9882c87edc438b97f534f28d7e2bbc6 /* ofxTimecode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTimecode.cpp; path = ../../ofxTimecode/src/ofxTimecode.cpp; sourceTree = SOURCE_ROOT; };
-		db375bbfeb77c75d4a4c3040d68281fb /* ofxTLFlags.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLFlags.cpp; path = ../src/ofxTLFlags.cpp; sourceTree = SOURCE_ROOT; };
-		dd476420fbc881796f865bb5fa4c12c7 /* ofxEasingSine.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingSine.h; path = ../../ofxTween/src/Easings/ofxEasingSine.h; sourceTree = SOURCE_ROOT; };
-		df90b9976feccfe157607af4463f9da0 /* ofxTLColors.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLColors.cpp; path = ../src/ofxTLColors.cpp; sourceTree = SOURCE_ROOT; };
-		e351bffb9fe51b25781f113575f5bbcd /* ofxTLImageSequenceFrame.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLImageSequenceFrame.h; path = ../src/ofxTLImageSequenceFrame.h; sourceTree = SOURCE_ROOT; };
-		e7379c3090a35247057d77fdade91aa0 /* ofxTLKeyframes.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLKeyframes.cpp; path = ../src/ofxTLKeyframes.cpp; sourceTree = SOURCE_ROOT; };
-		e8e616bc8e15dee74a54901f444f74a3 /* ofxTLTicker.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLTicker.cpp; path = ../src/ofxTLTicker.cpp; sourceTree = SOURCE_ROOT; };
-		ec09f970448422c45b6d1ebf77f17fde /* ofxTLTrackHeader.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLTrackHeader.cpp; path = ../src/ofxTLTrackHeader.cpp; sourceTree = SOURCE_ROOT; };
-		f1e73f8a9b812cbc0ee8dc880fe10d08 /* ofxTLCameraTrack.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxTLCameraTrack.h; path = ../src/ofxTLCameraTrack.h; sourceTree = SOURCE_ROOT; };
-		f71e87964e92020fb74d20d9c8850f29 /* ofxRemoveCocoaMenu.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxRemoveCocoaMenu.h; path = ../src/ofxRemoveCocoaMenu.h; sourceTree = SOURCE_ROOT; };
-		f9ba36c5a685069e2cbb73f48cfc2764 /* efx-presets.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = "efx-presets.h"; path = "../libs/sndfile/include/AL/efx-presets.h"; sourceTree = SOURCE_ROOT; };
-		fb8a50f8a34037bcd5dc10d0c3441a16 /* ofxEasingQuint.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingQuint.cpp; path = ../../ofxTween/src/Easings/ofxEasingQuint.cpp; sourceTree = SOURCE_ROOT; };
-		fc5da1c87211d4f6377da7199d8c5a1e /* tinyxmlparser.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = tinyxmlparser.cpp; path = ../../ofxXmlSettings/libs/tinyxmlparser.cpp; sourceTree = SOURCE_ROOT; };
-		fc9b34c5cb5b0acaff02ed20e6f129e7 /* ofxEasing.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasing.h; path = ../../ofxTween/src/Easings/ofxEasing.h; sourceTree = SOURCE_ROOT; };
-		fe4db52d544b8c725e615958d18ecbc4 /* ofxEasingElastic.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingElastic.h; path = ../../ofxTween/src/Easings/ofxEasingElastic.h; sourceTree = SOURCE_ROOT; };
-		fe7dd2bcb46b69f0ddc85191ab090e70 /* ofxTLAudioTrack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxTLAudioTrack.cpp; path = ../src/ofxTLAudioTrack.cpp; sourceTree = SOURCE_ROOT; };
+		FB8A50F8A34037BCD5DC10D0 /* ofxEasingQuint.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxEasingQuint.cpp; path = ../../../addons/ofxTween/src/Easings/ofxEasingQuint.cpp; sourceTree = SOURCE_ROOT; };
+		FC5DA1C87211D4F6377DA719 /* tinyxmlparser.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = tinyxmlparser.cpp; path = ../../../addons/ofxXmlSettings/libs/tinyxmlparser.cpp; sourceTree = SOURCE_ROOT; };
+		FC9B34C5CB5B0ACAFF02ED20 /* ofxEasing.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasing.h; path = ../../../addons/ofxTween/src/Easings/ofxEasing.h; sourceTree = SOURCE_ROOT; };
+		FE4DB52D544B8C725E615958 /* ofxEasingElastic.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxEasingElastic.h; path = ../../../addons/ofxTween/src/Easings/ofxEasingElastic.h; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -257,252 +234,440 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E778AED6163EF5AE003A40B1 /* OpenAL.framework in Frameworks */,
-				E7F985F815E0DEA3003869B5 /* Accelerate.framework in Frameworks */,
-				E7E077E815D3B6510020DFD4 /* QTKit.framework in Frameworks */,
-				E4EB6799138ADC1D00A09F29 /* GLUT.framework in Frameworks */,
+				85A041EF1AFCFB7F00819299 /* OpenAL.framework in Frameworks */,
+				85A041F01AFCFC8500819299 /* libsndfile.a in Frameworks */,
 				E4328149138ABC9F0047C5CB /* openFrameworksDebug.a in Frameworks */,
-				E45BE97B0E8CC7DD009D7055 /* AGL.framework in Frameworks */,
-				E45BE97C0E8CC7DD009D7055 /* ApplicationServices.framework in Frameworks */,
-				E45BE97D0E8CC7DD009D7055 /* AudioToolbox.framework in Frameworks */,
-				E45BE97E0E8CC7DD009D7055 /* Carbon.framework in Frameworks */,
-				E45BE97F0E8CC7DD009D7055 /* CoreAudio.framework in Frameworks */,
-				E45BE9800E8CC7DD009D7055 /* CoreFoundation.framework in Frameworks */,
-				E45BE9810E8CC7DD009D7055 /* CoreServices.framework in Frameworks */,
-				E45BE9830E8CC7DD009D7055 /* OpenGL.framework in Frameworks */,
-				E45BE9840E8CC7DD009D7055 /* QuickTime.framework in Frameworks */,
-				E4C2424710CC5A17004149E2 /* AppKit.framework in Frameworks */,
-				E4C2424810CC5A17004149E2 /* Cocoa.framework in Frameworks */,
-				E4C2424910CC5A17004149E2 /* IOKit.framework in Frameworks */,
-				E7E077E515D3B63C0020DFD4 /* CoreVideo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		11d541a012ed5066ea787e91fcea7ac8 /* libs */ = {
+		1F293A20D2B096D59C4F24DD /* ofxTween */ = {
 			isa = PBXGroup;
 			children = (
-				f122d593cd2892560a5b03c893f7b98a /* kiss */,
-				79433c413c03b5e0758af057f10b84fa /* ofOpenALSoundPlayer_TimelineAdditions */,
-				c3064ef956e24eacfd8fe45767b61193 /* sndfile */,
-			);
-			name = libs;
-			sourceTree = "<group>";
-		};
-		1f293a20d2b096d59c4f24ddc5226665 /* ofxTween */ = {
-			isa = PBXGroup;
-			children = (
-				81b62db6c371dad643503fef78aa1855 /* src */,
+				81B62DB6C371DAD643503FEF /* src */,
 			);
 			name = ofxTween;
 			sourceTree = "<group>";
 		};
-		1f4fb5c423662b96adfdcc0badec1cb0 /* ofxXmlSettings */ = {
+		1F4FB5C423662B96ADFDCC0B /* ofxXmlSettings */ = {
 			isa = PBXGroup;
 			children = (
-				6ecef0d76bc33727823eadffc320c44d /* src */,
-				6e54289412d2d94f45a051132369530c /* libs */,
+				6ECEF0D76BC33727823EADFF /* src */,
+				6E54289412D2D94F45A05113 /* libs */,
 			);
 			name = ofxXmlSettings;
 			sourceTree = "<group>";
 		};
-		3c8a947d9c8a0aa13fbe74e89a4c2854 /* ofxTimeline */ = {
+		6E54289412D2D94F45A05113 /* libs */ = {
 			isa = PBXGroup;
 			children = (
-				95ec4749e558adf7ecf154b0871e5f7e /* src */,
-				11d541a012ed5066ea787e91fcea7ac8 /* libs */,
-			);
-			name = ofxTimeline;
-			sourceTree = "<group>";
-		};
-		5d5c0ae687ac481a1ca3e1c200964ccc /* ofxMSATimer */ = {
-			isa = PBXGroup;
-			children = (
-				b0520b7d20d3f978fd7358785945208a /* src */,
-			);
-			name = ofxMSATimer;
-			sourceTree = "<group>";
-		};
-		6e54289412d2d94f45a051132369530c /* libs */ = {
-			isa = PBXGroup;
-			children = (
-				2b40eda85beb63e46785bc299a638898 /* tinyxml.cpp */,
-				b21e7e5f548eea92f368040bb1aa2f69 /* tinyxml.h */,
-				832bdc407620cdba568b713d2252c43c /* tinyxmlerror.cpp */,
-				fc5da1c87211d4f6377da7199d8c5a1e /* tinyxmlparser.cpp */,
+				2B40EDA85BEB63E46785BC29 /* tinyxml.cpp */,
+				B21E7E5F548EEA92F368040B /* tinyxml.h */,
+				832BDC407620CDBA568B713D /* tinyxmlerror.cpp */,
+				FC5DA1C87211D4F6377DA719 /* tinyxmlparser.cpp */,
 			);
 			name = libs;
 			sourceTree = "<group>";
 		};
-		6ecef0d76bc33727823eadffc320c44d /* src */ = {
+		6ECEF0D76BC33727823EADFF /* src */ = {
 			isa = PBXGroup;
 			children = (
-				50df87d612c5aae17aafa6c02c6bc570 /* ofxXmlSettings.cpp */,
-				01dcc0911400f9acf5b65578af4ec8f9 /* ofxXmlSettings.h */,
+				50DF87D612C5AAE17AAFA6C0 /* ofxXmlSettings.cpp */,
+				01DCC0911400F9ACF5B65578 /* ofxXmlSettings.h */,
 			);
 			name = src;
 			sourceTree = "<group>";
 		};
-		70ff9c14d29b092149d0cc4d17883251 /* include */ = {
+		81B62DB6C371DAD643503FEF /* src */ = {
 			isa = PBXGroup;
 			children = (
-				2f050e7223102a218b1fb7ecd05fc3f5 /* kiss_fft.h */,
-				bfee9391f78307b42aa09c9afad043a8 /* kiss_fftr.h */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		79433c413c03b5e0758af057f10b84fa /* ofOpenALSoundPlayer_TimelineAdditions */ = {
-			isa = PBXGroup;
-			children = (
-				E72139FD16BCCDD60011637E /* src */,
-			);
-			name = ofOpenALSoundPlayer_TimelineAdditions;
-			sourceTree = "<group>";
-		};
-		81b62db6c371dad643503fef78aa1855 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				b59ddd3c0eb9ffc71f28869b15a0ff91 /* Easings */,
-				497f252390399fcf843297da0271f914 /* ofxTween.cpp */,
-				3dc6648a0468fbecb5e45b57040e9eb5 /* ofxTween.h */,
+				B59DDD3C0EB9FFC71F28869B /* Easings */,
+				497F252390399FCF843297DA /* ofxTween.cpp */,
+				3DC6648A0468FBECB5E45B57 /* ofxTween.h */,
 			);
 			name = src;
 			sourceTree = "<group>";
 		};
-		86df17850277042c979393f5dbd67836 /* src */ = {
+		85F9883D1AFCDE3200BA7587 /* ofxTimeline */ = {
 			isa = PBXGroup;
 			children = (
-				22ec628e5fa510d7034a99bb49ae8da8 /* ofRange.h */,
+				85F9883E1AFCDE3200BA7587 /* src */,
+				85F988781AFCDE3200BA7587 /* libs */,
+			);
+			name = ofxTimeline;
+			sourceTree = "<group>";
+		};
+		85F9883E1AFCDE3200BA7587 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				85F9883F1AFCDE3200BA7587 /* ofxHotKeys.h */,
+				85F988401AFCDE3200BA7587 /* ofxHotKeys_impl_linux.cpp */,
+				85F988411AFCDE3200BA7587 /* ofxHotKeys_impl_mac.mm */,
+				85F988421AFCDE3200BA7587 /* ofxHotKeys_impl_win.cpp */,
+				85F988431AFCDE3200BA7587 /* ofxRemoveCocoaMenu.h */,
+				85F988441AFCDE3200BA7587 /* ofxRemoveCocoaMenu.mm */,
+				85F988451AFCDE3200BA7587 /* ofxTimeline.cpp */,
+				85F988461AFCDE3200BA7587 /* ofxTimeline.h */,
+				85F988471AFCDE3200BA7587 /* ofxTLAudioTrack.cpp */,
+				85F988481AFCDE3200BA7587 /* ofxTLAudioTrack.h */,
+				85F988491AFCDE3200BA7587 /* ofxTLBangs.cpp */,
+				85F9884A1AFCDE3200BA7587 /* ofxTLBangs.h */,
+				85F9884B1AFCDE3200BA7587 /* ofxTLCameraTrack.cpp */,
+				85F9884C1AFCDE3200BA7587 /* ofxTLCameraTrack.h */,
+				85F9884D1AFCDE3200BA7587 /* ofxTLColors.cpp */,
+				85F9884E1AFCDE3200BA7587 /* ofxTLColors.h */,
+				85F9884F1AFCDE3200BA7587 /* ofxTLColorTrack.cpp */,
+				85F988501AFCDE3200BA7587 /* ofxTLColorTrack.h */,
+				85F988511AFCDE3200BA7587 /* ofxTLCurves.cpp */,
+				85F988521AFCDE3200BA7587 /* ofxTLCurves.h */,
+				85F988531AFCDE3200BA7587 /* ofxTLEmptyKeyframes.cpp */,
+				85F988541AFCDE3200BA7587 /* ofxTLEmptyKeyframes.h */,
+				85F988551AFCDE3200BA7587 /* ofxTLEmptyTrack.cpp */,
+				85F988561AFCDE3200BA7587 /* ofxTLEmptyTrack.h */,
+				85F988571AFCDE3200BA7587 /* ofxTLEvents.h */,
+				85F988581AFCDE3200BA7587 /* ofxTLFlags.cpp */,
+				85F988591AFCDE3200BA7587 /* ofxTLFlags.h */,
+				85F9885A1AFCDE3200BA7587 /* ofxTLImageSequence.cpp */,
+				85F9885B1AFCDE3200BA7587 /* ofxTLImageSequence.h */,
+				85F9885C1AFCDE3200BA7587 /* ofxTLImageSequenceFrame.cpp */,
+				85F9885D1AFCDE3200BA7587 /* ofxTLImageSequenceFrame.h */,
+				85F9885E1AFCDE3200BA7587 /* ofxTLImageTrack.cpp */,
+				85F9885F1AFCDE3200BA7587 /* ofxTLImageTrack.h */,
+				85F988601AFCDE3200BA7587 /* ofxTLInOut.cpp */,
+				85F988611AFCDE3200BA7587 /* ofxTLInOut.h */,
+				85F988621AFCDE3200BA7587 /* ofxTLKeyframes.cpp */,
+				85F988631AFCDE3200BA7587 /* ofxTLKeyframes.h */,
+				85F988641AFCDE3200BA7587 /* ofxTLLFO.cpp */,
+				85F988651AFCDE3200BA7587 /* ofxTLLFO.h */,
+				85F988661AFCDE3200BA7587 /* ofxTLPage.cpp */,
+				85F988671AFCDE3200BA7587 /* ofxTLPage.h */,
+				85F988681AFCDE3200BA7587 /* ofxTLPageTabs.cpp */,
+				85F988691AFCDE3200BA7587 /* ofxTLPageTabs.h */,
+				85F9886A1AFCDE3200BA7587 /* ofxTLSwitches.cpp */,
+				85F9886B1AFCDE3200BA7587 /* ofxTLSwitches.h */,
+				85F9886C1AFCDE3200BA7587 /* ofxTLTicker.cpp */,
+				85F9886D1AFCDE3200BA7587 /* ofxTLTicker.h */,
+				85F9886E1AFCDE3200BA7587 /* ofxTLTrack.cpp */,
+				85F9886F1AFCDE3200BA7587 /* ofxTLTrack.h */,
+				85F988701AFCDE3200BA7587 /* ofxTLTrackHeader.cpp */,
+				85F988711AFCDE3200BA7587 /* ofxTLTrackHeader.h */,
+				85F988721AFCDE3200BA7587 /* ofxTLVideoThumb.cpp */,
+				85F988731AFCDE3200BA7587 /* ofxTLVideoThumb.h */,
+				85F988741AFCDE3200BA7587 /* ofxTLVideoTrack.cpp */,
+				85F988751AFCDE3200BA7587 /* ofxTLVideoTrack.h */,
+				85F988761AFCDE3200BA7587 /* ofxTLZoomer.cpp */,
+				85F988771AFCDE3200BA7587 /* ofxTLZoomer.h */,
+			);
+			name = src;
+			path = ../src;
+			sourceTree = "<group>";
+		};
+		85F988781AFCDE3200BA7587 /* libs */ = {
+			isa = PBXGroup;
+			children = (
+				85F988791AFCDE3200BA7587 /* kiss */,
+				85F988811AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions */,
+				85F988851AFCDE3200BA7587 /* openal */,
+				85F9889B1AFCDE3200BA7587 /* sndfile */,
+			);
+			name = libs;
+			path = ../libs;
+			sourceTree = "<group>";
+		};
+		85F988791AFCDE3200BA7587 /* kiss */ = {
+			isa = PBXGroup;
+			children = (
+				85F9887A1AFCDE3200BA7587 /* include */,
+				85F9887D1AFCDE3200BA7587 /* src */,
+			);
+			path = kiss;
+			sourceTree = "<group>";
+		};
+		85F9887A1AFCDE3200BA7587 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				85F9887B1AFCDE3200BA7587 /* kiss_fft.h */,
+				85F9887C1AFCDE3200BA7587 /* kiss_fftr.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		85F9887D1AFCDE3200BA7587 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				85F9887E1AFCDE3200BA7587 /* _kiss_fft_guts.h */,
+				85F9887F1AFCDE3200BA7587 /* kiss_fft.c */,
+				85F988801AFCDE3200BA7587 /* kiss_fftr.c */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		85F988811AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions */ = {
+			isa = PBXGroup;
+			children = (
+				85F988821AFCDE3200BA7587 /* src */,
+			);
+			path = ofOpenALSoundPlayer_TimelineAdditions;
+			sourceTree = "<group>";
+		};
+		85F988821AFCDE3200BA7587 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				85F988831AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.cpp */,
+				85F988841AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.h */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		85F988851AFCDE3200BA7587 /* openal */ = {
+			isa = PBXGroup;
+			children = (
+				85F988861AFCDE3200BA7587 /* include */,
+				85F9888E1AFCDE3200BA7587 /* libs */,
+			);
+			path = openal;
+			sourceTree = "<group>";
+		};
+		85F988861AFCDE3200BA7587 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				85F988871AFCDE3200BA7587 /* AL */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		85F988871AFCDE3200BA7587 /* AL */ = {
+			isa = PBXGroup;
+			children = (
+				85F988881AFCDE3200BA7587 /* al.h */,
+				85F988891AFCDE3200BA7587 /* alc.h */,
+				85F9888A1AFCDE3200BA7587 /* efx-creative.h */,
+				85F9888B1AFCDE3200BA7587 /* EFX-Util.h */,
+				85F9888C1AFCDE3200BA7587 /* efx.h */,
+				85F9888D1AFCDE3200BA7587 /* xram.h */,
+			);
+			path = AL;
+			sourceTree = "<group>";
+		};
+		85F9888E1AFCDE3200BA7587 /* libs */ = {
+			isa = PBXGroup;
+			children = (
+				85F9888F1AFCDE3200BA7587 /* vs2010 */,
+				85F988951AFCDE3200BA7587 /* win_cb */,
+			);
+			path = libs;
+			sourceTree = "<group>";
+		};
+		85F9888F1AFCDE3200BA7587 /* vs2010 */ = {
+			isa = PBXGroup;
+			children = (
+				85F988901AFCDE3200BA7587 /* EFX-Util_MT */,
+				85F988921AFCDE3200BA7587 /* EFX-Util_MTDLL */,
+				85F988941AFCDE3200BA7587 /* OpenAL32.lib */,
+			);
+			path = vs2010;
+			sourceTree = "<group>";
+		};
+		85F988901AFCDE3200BA7587 /* EFX-Util_MT */ = {
+			isa = PBXGroup;
+			children = (
+				85F988911AFCDE3200BA7587 /* EFX-Util.lib */,
+			);
+			path = "EFX-Util_MT";
+			sourceTree = "<group>";
+		};
+		85F988921AFCDE3200BA7587 /* EFX-Util_MTDLL */ = {
+			isa = PBXGroup;
+			children = (
+				85F988931AFCDE3200BA7587 /* EFX-Util.lib */,
+			);
+			path = "EFX-Util_MTDLL";
+			sourceTree = "<group>";
+		};
+		85F988951AFCDE3200BA7587 /* win_cb */ = {
+			isa = PBXGroup;
+			children = (
+				85F988961AFCDE3200BA7587 /* EFX-Util_MT */,
+				85F988981AFCDE3200BA7587 /* EFX-Util_MTDLL */,
+				85F9889A1AFCDE3200BA7587 /* OpenAL32.lib */,
+			);
+			path = win_cb;
+			sourceTree = "<group>";
+		};
+		85F988961AFCDE3200BA7587 /* EFX-Util_MT */ = {
+			isa = PBXGroup;
+			children = (
+				85F988971AFCDE3200BA7587 /* EFX-Util.lib */,
+			);
+			path = "EFX-Util_MT";
+			sourceTree = "<group>";
+		};
+		85F988981AFCDE3200BA7587 /* EFX-Util_MTDLL */ = {
+			isa = PBXGroup;
+			children = (
+				85F988991AFCDE3200BA7587 /* EFX-Util.lib */,
+			);
+			path = "EFX-Util_MTDLL";
+			sourceTree = "<group>";
+		};
+		85F9889B1AFCDE3200BA7587 /* sndfile */ = {
+			isa = PBXGroup;
+			children = (
+				85F9889C1AFCDE3200BA7587 /* include */,
+				85F9889F1AFCDE3200BA7587 /* lib */,
+				85F988A61AFCDE3200BA7587 /* redist */,
+			);
+			path = sndfile;
+			sourceTree = "<group>";
+		};
+		85F9889C1AFCDE3200BA7587 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				85F9889D1AFCDE3200BA7587 /* sndfile.h */,
+				85F9889E1AFCDE3200BA7587 /* sndfile.hh */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		85F9889F1AFCDE3200BA7587 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				85F988A01AFCDE3200BA7587 /* osx */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		85F988A01AFCDE3200BA7587 /* osx */ = {
+			isa = PBXGroup;
+			children = (
+				85F988A11AFCDE3200BA7587 /* libsndfile.a */,
+			);
+			path = osx;
+			sourceTree = "<group>";
+		};
+		85F988A61AFCDE3200BA7587 /* redist */ = {
+			isa = PBXGroup;
+			children = (
+				85F988A71AFCDE3200BA7587 /* libsndfile-1.dll */,
+			);
+			path = redist;
+			sourceTree = "<group>";
+		};
+		85F988CF1AFCDE3300BA7587 /* ofxMSATimer */ = {
+			isa = PBXGroup;
+			children = (
+				85F988D01AFCDE3300BA7587 /* src */,
+			);
+			name = ofxMSATimer;
+			sourceTree = "<group>";
+		};
+		85F988D01AFCDE3300BA7587 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				85F988D11AFCDE3300BA7587 /* ofxMSATimer.cpp */,
+				85F988D21AFCDE3300BA7587 /* ofxMSATimer.h */,
+			);
+			name = src;
+			path = ../../ofxMSATimer/src;
+			sourceTree = "<group>";
+		};
+		86DF17850277042C979393F5 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				22EC628E5FA510D7034A99BB /* ofRange.h */,
 			);
 			name = src;
 			sourceTree = "<group>";
 		};
-		8efd6815c031741ffaa1a0012419f7cf /* ofxTimecode */ = {
+		8EFD6815C031741FFAA1A001 /* ofxTimecode */ = {
 			isa = PBXGroup;
 			children = (
-				abe37a0bb21b3d890efc285b57b7e0d9 /* src */,
+				ABE37A0BB21B3D890EFC285B /* src */,
 			);
 			name = ofxTimecode;
 			sourceTree = "<group>";
 		};
-		95ec4749e558adf7ecf154b0871e5f7e /* src */ = {
+		9FD9332064A1194AC3CD20C2 /* ofxRange */ = {
 			isa = PBXGroup;
 			children = (
-				6146999aa0b432590d07eb521d43e191 /* ofxHotKeys.h */,
-				4d892fbbb9e438c35b8c5ee430082e72 /* ofxHotKeys_impl_linux.cpp */,
-				2506aa6a6ef4e116e23a1c24c5fbd57f /* ofxHotKeys_impl_mac.mm */,
-				30666c151f907fce97822a8a38b276a6 /* ofxHotKeys_impl_win.cpp */,
-				f71e87964e92020fb74d20d9c8850f29 /* ofxRemoveCocoaMenu.h */,
-				8f610deb3752f20ff149bc096963cf80 /* ofxRemoveCocoaMenu.mm */,
-				173c557b81a5be86d194eeb6d6250f91 /* ofxTimeline.cpp */,
-				9a2f1d6ae148cd25f6bea00506177bc5 /* ofxTimeline.h */,
-				fe7dd2bcb46b69f0ddc85191ab090e70 /* ofxTLAudioTrack.cpp */,
-				6bc7dd2c4e83a707848be258865dbb01 /* ofxTLAudioTrack.h */,
-				689fe82c6569027132ca3ee568a4ee1e /* ofxTLBangs.cpp */,
-				9d86b2b57c2f171846dfeaf4c063c399 /* ofxTLBangs.h */,
-				0d65e6a2e0f22f72aa7670d7733a180e /* ofxTLCameraTrack.cpp */,
-				f1e73f8a9b812cbc0ee8dc880fe10d08 /* ofxTLCameraTrack.h */,
-				df90b9976feccfe157607af4463f9da0 /* ofxTLColors.cpp */,
-				afcc811df430141d32bab3ebf9ba8734 /* ofxTLColors.h */,
-				3d5a2b98580af9336c8c1886c7a2324d /* ofxTLColorTrack.cpp */,
-				53a47d9878535b9b1670047561971d02 /* ofxTLColorTrack.h */,
-				7f47d144dc8b3e5cd297eaf57dc4f889 /* ofxTLCurves.cpp */,
-				50511502e9cfd66a7bb161f2bfee7db5 /* ofxTLCurves.h */,
-				4fddcdd6e0eed2f5edd672855798f064 /* ofxTLEmptyKeyframes.cpp */,
-				56d0182470bf6d3d6de9541980e67f8b /* ofxTLEmptyKeyframes.h */,
-				32d83269769d4d7e74bf125b5842071d /* ofxTLEmptyTrack.cpp */,
-				54e92bcd121baa568ec9b4fb6198d262 /* ofxTLEmptyTrack.h */,
-				a365e230090b71900f9a7987aa6fccec /* ofxTLEvents.h */,
-				db375bbfeb77c75d4a4c3040d68281fb /* ofxTLFlags.cpp */,
-				2a99d747f2315daf1fb4f247021e7445 /* ofxTLFlags.h */,
-				236d66ae5b5c95729bfa6c29568f259b /* ofxTLImageSequence.cpp */,
-				09cbd28db823fe305eb470eeba6c4f78 /* ofxTLImageSequence.h */,
-				ccf76a8f53c203272707f428c7128157 /* ofxTLImageSequenceFrame.cpp */,
-				e351bffb9fe51b25781f113575f5bbcd /* ofxTLImageSequenceFrame.h */,
-				3e8baad02914d140c0ced3d7a9533896 /* ofxTLImageTrack.cpp */,
-				3dbb60625304a9174a9a9635f98e40a7 /* ofxTLImageTrack.h */,
-				215341b77a15aa8d842ed2f0c66df3e8 /* ofxTLInOut.cpp */,
-				883c9e7fc087dbbc061aed5d10b268ef /* ofxTLInOut.h */,
-				e7379c3090a35247057d77fdade91aa0 /* ofxTLKeyframes.cpp */,
-				b9fd7617cf5f462774962af9384ef0ac /* ofxTLKeyframes.h */,
-				39833d65fff88a58c3cb8bdf62a80afb /* ofxTLLFO.cpp */,
-				68eb873762b550705aa7464c7dfffede /* ofxTLLFO.h */,
-				16bec8b1201859a26e3ffbc0b31ab24e /* ofxTLPage.cpp */,
-				bc6bde994c25a3b82b30f694893b581f /* ofxTLPage.h */,
-				740abfc3dd8b605bb9c55d805231d094 /* ofxTLPageTabs.cpp */,
-				3241b8bdc0b27471f8ee25d5a3db58b2 /* ofxTLPageTabs.h */,
-				5d23395ac4260312d47bb9588e732fd1 /* ofxTLSwitches.cpp */,
-				66c910bfbec609d16e3b249a8448466d /* ofxTLSwitches.h */,
-				e8e616bc8e15dee74a54901f444f74a3 /* ofxTLTicker.cpp */,
-				410e5fe3eb7fe9cb2726d36d724fd561 /* ofxTLTicker.h */,
-				a5c128c6d62190c88cc9ab3b401d6e25 /* ofxTLTrack.cpp */,
-				96033bf9d1ef22715e6afdc3b189dbc8 /* ofxTLTrack.h */,
-				ec09f970448422c45b6d1ebf77f17fde /* ofxTLTrackHeader.cpp */,
-				3d0621ce540a64d8d27e0af7f83b3eb2 /* ofxTLTrackHeader.h */,
-				a208db91709b73833548f57d7336831e /* ofxTLVideoThumb.cpp */,
-				2af40c99324fbebe7bab30147fc27af8 /* ofxTLVideoThumb.h */,
-				16644a54427c234fd75cb89d48524e02 /* ofxTLVideoTrack.cpp */,
-				8e52dc6b4ea21969c85b8e832936acc3 /* ofxTLVideoTrack.h */,
-				c7a760ce8107cc5bb8ecbd37a5609bf9 /* ofxTLZoomer.cpp */,
-				1a433a24e8182dd578600bffe7ac6da5 /* ofxTLZoomer.h */,
+				86DF17850277042C979393F5 /* src */,
+			);
+			name = ofxRange;
+			sourceTree = "<group>";
+		};
+		A84C320C111785EEEE9DEB83 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				BCB6A6D9093FF11EE0D7D470 /* ofxTextInputField.cpp */,
+				AC5DDD8BBD12E8E173E4AE81 /* ofxTextInputField.h */,
+				3D5A874AE34061363E1C19B1 /* ofxTextInputFieldFontRenderer.h */,
 			);
 			name = src;
 			sourceTree = "<group>";
 		};
-		9fd9332064a1194ac3cd20c226cc5a32 /* ofxRange */ = {
+		AB88B4FD5D7F4ABF53230E5A /* ofxTextInputField */ = {
 			isa = PBXGroup;
 			children = (
-				86df17850277042c979393f5dbd67836 /* src */,
+				A84C320C111785EEEE9DEB83 /* src */,
 			);
-			name = ofxRange;
+			name = ofxTextInputField;
+			sourceTree = "<group>";
+		};
+		ABE37A0BB21B3D890EFC285B /* src */ = {
+			isa = PBXGroup;
+			children = (
+				D9882C87EDC438B97F534F28 /* ofxTimecode.cpp */,
+				95C5241B62F5D1F0FE6C067B /* ofxTimecode.h */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		B59DDD3C0EB9FFC71F28869B /* Easings */ = {
+			isa = PBXGroup;
+			children = (
+				9AAEF50558BBDBEB5260FC35 /* easing_terms_of_use.html */,
+				26E160699149D8AF609734A1 /* ofxEasing.cpp */,
+				FC9B34C5CB5B0ACAFF02ED20 /* ofxEasing.h */,
+				7660DD2BE873BAD12E3A496D /* ofxEasingBack.cpp */,
+				7912619B786F0238D22ED5F3 /* ofxEasingBack.h */,
+				00B7E2794A10F926DF630529 /* ofxEasingBounce.cpp */,
+				A9FE46C20E767B29C5997AD3 /* ofxEasingBounce.h */,
+				A4973CEF438C8931B5E03E0A /* ofxEasingCirc.cpp */,
+				AF17EB492DB2858A0EBD94CD /* ofxEasingCirc.h */,
+				34AA5DBAF88C8B757B46D40D /* ofxEasingCubic.cpp */,
+				B788152C3FE538E700D063C7 /* ofxEasingCubic.h */,
+				A26C4A6254126C99F0A65354 /* ofxEasingElastic.cpp */,
+				FE4DB52D544B8C725E615958 /* ofxEasingElastic.h */,
+				0F26D4EDFF0E9EA8CF68B694 /* ofxEasingExpo.cpp */,
+				767479279EBAC134D46E74E7 /* ofxEasingExpo.h */,
+				9A4CFDCEA412E8BCDACA9B26 /* ofxEasingLinear.cpp */,
+				7599804C6260EC1CD8D3567D /* ofxEasingLinear.h */,
+				B9E1DB01BD6701283FC87946 /* ofxEasingQuad.cpp */,
+				B07C508E7717E6C892502ADF /* ofxEasingQuad.h */,
+				882494DB324414B7B31DB11C /* ofxEasingQuart.cpp */,
+				4C0E055E4176057631087AA3 /* ofxEasingQuart.h */,
+				FB8A50F8A34037BCD5DC10D0 /* ofxEasingQuint.cpp */,
+				5E9E6513BEC36148928518B7 /* ofxEasingQuint.h */,
+				5FABA58C3070AF2F33E8C257 /* ofxEasingSine.cpp */,
+				DD476420FBC881796F865BB5 /* ofxEasingSine.h */,
+			);
+			name = Easings;
 			sourceTree = "<group>";
 		};
 		BB4B014C10F69532006C3DED /* addons */ = {
 			isa = PBXGroup;
 			children = (
-				1f4fb5c423662b96adfdcc0badec1cb0 /* ofxXmlSettings */,
-				5d5c0ae687ac481a1ca3e1c200964ccc /* ofxMSATimer */,
-				9fd9332064a1194ac3cd20c226cc5a32 /* ofxRange */,
-				ab88b4fd5d7f4abf53230e5a327c1368 /* ofxTextInputField */,
-				8efd6815c031741ffaa1a0012419f7cf /* ofxTimecode */,
-				3c8a947d9c8a0aa13fbe74e89a4c2854 /* ofxTimeline */,
-				1f293a20d2b096d59c4f24ddc5226665 /* ofxTween */,
+				9FD9332064A1194AC3CD20C2 /* ofxRange */,
+				AB88B4FD5D7F4ABF53230E5A /* ofxTextInputField */,
+				8EFD6815C031741FFAA1A001 /* ofxTimecode */,
+				1F293A20D2B096D59C4F24DD /* ofxTween */,
+				1F4FB5C423662B96ADFDCC0B /* ofxXmlSettings */,
+				85F9883D1AFCDE3200BA7587 /* ofxTimeline */,
+				85F988CF1AFCDE3300BA7587 /* ofxMSATimer */,
 			);
 			name = addons;
-			sourceTree = "<group>";
-		};
-		BBAB23C913894ECA00AA2426 /* system frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				E778AED5163EF5AE003A40B1 /* OpenAL.framework */,
-				E7F985F515E0DE99003869B5 /* Accelerate.framework */,
-				E4C2424410CC5A17004149E2 /* AppKit.framework */,
-				E4C2424510CC5A17004149E2 /* Cocoa.framework */,
-				E4C2424610CC5A17004149E2 /* IOKit.framework */,
-				E45BE9710E8CC7DD009D7055 /* AGL.framework */,
-				E45BE9720E8CC7DD009D7055 /* ApplicationServices.framework */,
-				E45BE9730E8CC7DD009D7055 /* AudioToolbox.framework */,
-				E45BE9740E8CC7DD009D7055 /* Carbon.framework */,
-				E45BE9750E8CC7DD009D7055 /* CoreAudio.framework */,
-				E45BE9760E8CC7DD009D7055 /* CoreFoundation.framework */,
-				E45BE9770E8CC7DD009D7055 /* CoreServices.framework */,
-				E45BE9790E8CC7DD009D7055 /* OpenGL.framework */,
-				E45BE97A0E8CC7DD009D7055 /* QuickTime.framework */,
-				E7E077E415D3B63C0020DFD4 /* CoreVideo.framework */,
-				E7E077E715D3B6510020DFD4 /* QTKit.framework */,
-			);
-			name = "system frameworks";
-			sourceTree = "<group>";
-		};
-		BBAB23CA13894EDB00AA2426 /* 3rd party frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BBAB23BE13894E4700AA2426 /* GLUT.framework */,
-			);
-			name = "3rd party frameworks";
 			sourceTree = "<group>";
 		};
 		E4328144138ABC890047C5CB /* Products */ = {
@@ -513,24 +678,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		E45BE5980E8CC70C009D7055 /* frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BBAB23CA13894EDB00AA2426 /* 3rd party frameworks */,
-				BBAB23C913894ECA00AA2426 /* system frameworks */,
-			);
-			name = frameworks;
-			sourceTree = "<group>";
-		};
 		E4B69B4A0A3A1720003C02F2 = {
 			isa = PBXGroup;
 			children = (
+				85A041EE1AFCFB7F00819299 /* OpenAL.framework */,
 				E4B6FCAD0C3E899E008CF71C /* openFrameworks-Info.plist */,
 				E4EB6923138AFD0F00A09F29 /* Project.xcconfig */,
 				E4B69E1C0A3A1BDC003C02F2 /* src */,
 				E4EEC9E9138DF44700A80321 /* openFrameworks */,
 				BB4B014C10F69532006C3DED /* addons */,
-				E45BE5980E8CC70C009D7055 /* frameworks */,
 				E4B69B5B0A3A1756003C02F2 /* example-allTracksDebug.app */,
 			);
 			sourceTree = "<group>";
@@ -539,8 +695,8 @@
 			isa = PBXGroup;
 			children = (
 				E4B69E1D0A3A1BDC003C02F2 /* main.cpp */,
-				E4B69E1F0A3A1BDC003C02F2 /* testApp.h */,
-				E4B69E1E0A3A1BDC003C02F2 /* testApp.cpp */,
+				E4B69E1E0A3A1BDC003C02F2 /* ofApp.cpp */,
+				E4B69E1F0A3A1BDC003C02F2 /* ofApp.h */,
 			);
 			path = src;
 			sourceTree = SOURCE_ROOT;
@@ -552,132 +708,6 @@
 				E4328143138ABC890047C5CB /* openFrameworksLib.xcodeproj */,
 			);
 			name = openFrameworks;
-			sourceTree = "<group>";
-		};
-		E72139FD16BCCDD60011637E /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E72139FE16BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.cpp */,
-				E72139FF16BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.h */,
-			);
-			name = src;
-			path = ../libs/ofOpenALSoundPlayer_TimelineAdditions/src;
-			sourceTree = "<group>";
-		};
-		a84c320c111785eeee9deb836e25dc1f /* src */ = {
-			isa = PBXGroup;
-			children = (
-				bcb6a6d9093ff11ee0d7d470a2de47c9 /* ofxTextInputField.cpp */,
-				ac5ddd8bbd12e8e173e4ae81a6b924bc /* ofxTextInputField.h */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		ab88b4fd5d7f4abf53230e5a327c1368 /* ofxTextInputField */ = {
-			isa = PBXGroup;
-			children = (
-				a84c320c111785eeee9deb836e25dc1f /* src */,
-			);
-			name = ofxTextInputField;
-			sourceTree = "<group>";
-		};
-		abe37a0bb21b3d890efc285b57b7e0d9 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				d9882c87edc438b97f534f28d7e2bbc6 /* ofxTimecode.cpp */,
-				95c5241b62f5d1f0fe6c067b5331bca8 /* ofxTimecode.h */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		b0520b7d20d3f978fd7358785945208a /* src */ = {
-			isa = PBXGroup;
-			children = (
-				b4ebe6922de4dcb97639b65f848e477b /* ofxMSATimer.cpp */,
-				03dde55c47701116edeb18007fc4bf75 /* ofxMSATimer.h */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		b59ddd3c0eb9ffc71f28869b15a0ff91 /* Easings */ = {
-			isa = PBXGroup;
-			children = (
-				9aaef50558bbdbeb5260fc353bfd02d1 /* easing_terms_of_use.html */,
-				26e160699149d8af609734a1b63d80e2 /* ofxEasing.cpp */,
-				fc9b34c5cb5b0acaff02ed20e6f129e7 /* ofxEasing.h */,
-				7660dd2be873bad12e3a496d995f14e4 /* ofxEasingBack.cpp */,
-				7912619b786f0238d22ed5f3c10786f2 /* ofxEasingBack.h */,
-				00b7e2794a10f926df6305296b86a351 /* ofxEasingBounce.cpp */,
-				a9fe46c20e767b29c5997ad3a88b9f7b /* ofxEasingBounce.h */,
-				a4973cef438c8931b5e03e0a3b5d05b5 /* ofxEasingCirc.cpp */,
-				af17eb492db2858a0ebd94cd64092fb9 /* ofxEasingCirc.h */,
-				34aa5dbaf88c8b757b46d40d80b9047b /* ofxEasingCubic.cpp */,
-				b788152c3fe538e700d063c7d17da903 /* ofxEasingCubic.h */,
-				a26c4a6254126c99f0a65354aa3cbcd0 /* ofxEasingElastic.cpp */,
-				fe4db52d544b8c725e615958d18ecbc4 /* ofxEasingElastic.h */,
-				0f26d4edff0e9ea8cf68b694a2265e4f /* ofxEasingExpo.cpp */,
-				767479279ebac134d46e74e76dc9f79f /* ofxEasingExpo.h */,
-				9a4cfdcea412e8bcdaca9b26fb47846e /* ofxEasingLinear.cpp */,
-				7599804c6260ec1cd8d3567dc11aa06a /* ofxEasingLinear.h */,
-				b9e1db01bd6701283fc879469dcb8bc0 /* ofxEasingQuad.cpp */,
-				b07c508e7717e6c892502adf5fddc285 /* ofxEasingQuad.h */,
-				882494db324414b7b31db11cc14948d9 /* ofxEasingQuart.cpp */,
-				4c0e055e4176057631087aa3938a7c76 /* ofxEasingQuart.h */,
-				fb8a50f8a34037bcd5dc10d0c3441a16 /* ofxEasingQuint.cpp */,
-				5e9e6513bec36148928518b774158396 /* ofxEasingQuint.h */,
-				5faba58c3070af2f33e8c257343cea16 /* ofxEasingSine.cpp */,
-				dd476420fbc881796f865bb5fa4c12c7 /* ofxEasingSine.h */,
-			);
-			name = Easings;
-			sourceTree = "<group>";
-		};
-		b7fb12801274cae3603ea4cfdecec294 /* AL */ = {
-			isa = PBXGroup;
-			children = (
-				c5b9174723940db207e7ab82b583bc7d /* al.h */,
-				0c578fcc784a6245c49aee60b6681712 /* alc.h */,
-				ba109f25bb170b74a96b155fe64e5f9b /* alext.h */,
-				0d63c00fb3a729e001961ab70e84fb9d /* efx-creative.h */,
-				f9ba36c5a685069e2cbb73f48cfc2764 /* efx-presets.h */,
-				b7886c7b71ddb1e4091232870f09bb9e /* efx.h */,
-			);
-			name = AL;
-			sourceTree = "<group>";
-		};
-		c3064ef956e24eacfd8fe45767b61193 /* sndfile */ = {
-			isa = PBXGroup;
-			children = (
-				e7558d68ea34b87a36db465c78f95890 /* include */,
-			);
-			name = sndfile;
-			sourceTree = "<group>";
-		};
-		e1ad38c5f775f42c90542e371f9991a1 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				4b817954d44bdb7ede7da278e95facfa /* _kiss_fft_guts.h */,
-				d0fd108aa97d6409b427947c78757928 /* kiss_fft.c */,
-				b86c4bcf6618e3505813c304817a9b6f /* kiss_fftr.c */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		e7558d68ea34b87a36db465c78f95890 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				b7fb12801274cae3603ea4cfdecec294 /* AL */,
-				4162e24aefc4c866df24e11560269162 /* sndfile.h */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		f122d593cd2892560a5b03c893f7b98a /* kiss */ = {
-			isa = PBXGroup;
-			children = (
-				70ff9c14d29b092149d0cc4d17883251 /* include */,
-				e1ad38c5f775f42c90542e371f9991a1 /* src */,
-			);
-			name = kiss;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -707,8 +737,11 @@
 /* Begin PBXProject section */
 		E4B69B4C0A3A1720003C02F2 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0600;
+			};
 			buildConfigurationList = E4B69B4D0A3A1720003C02F2 /* Build configuration list for PBXProject "example-allTracks" */;
-			compatibilityVersion = "Xcode 2.4";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -755,7 +788,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp -f ../../../libs/fmodex/lib/osx/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/libfmodex.dylib\"; install_name_tool -change ./libfmodex.dylib @executable_path/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";";
+			shellScript = "cp -f ../../../libs/fmodex/lib/osx/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/libfmodex.dylib\"; install_name_tool -change ./libfmodex.dylib @executable_path/libfmodex.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\nmkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\ncp -f \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -764,61 +797,61 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				85F988C11AFCDE3200BA7587 /* ofxTLTrackHeader.cpp in Sources */,
+				85F988BC1AFCDE3200BA7587 /* ofxTLPage.cpp in Sources */,
+				85F988BF1AFCDE3200BA7587 /* ofxTLTicker.cpp in Sources */,
 				E4B69E200A3A1BDC003C02F2 /* main.cpp in Sources */,
-				E4B69E210A3A1BDC003C02F2 /* testApp.cpp in Sources */,
-				63b57ac5bf4ef088491e0317dbb2ecaa /* ofxXmlSettings.cpp in Sources */,
-				933a2227713c720ceff80fd967d0a8ee /* tinyxml.cpp in Sources */,
-				9d44dc88ef9e7991b4a09951e2e4769f /* tinyxmlerror.cpp in Sources */,
-				5a4349e9754d6fa14c0f2a3a1abc30b6 /* tinyxmlparser.cpp in Sources */,
-				9119bfc53670a98106e367bbc1bd167a /* ofxMSATimer.cpp in Sources */,
-				f6ca03081709fcbfdaef66765f9e376e /* ofxTextInputField.cpp in Sources */,
-				6499b8489905bfe9067f8db81e6bbfdf /* ofxTimecode.cpp in Sources */,
-				5da2e0e8ecdb5b4e2908167d7b74de63 /* ofxHotKeys_impl_linux.cpp in Sources */,
-				7d7ecd8dd8eb4244d7a87f40ba8c53cd /* ofxHotKeys_impl_mac.mm in Sources */,
-				e904ef309b050587cf73df2173a531a6 /* ofxHotKeys_impl_win.cpp in Sources */,
-				fd525b9bc71cf001cac34c5a87c2672f /* ofxRemoveCocoaMenu.mm in Sources */,
-				7ac6376b15bcf4d368ec068f0ecce711 /* ofxTimeline.cpp in Sources */,
-				14ed851279c06f2bcf0bf27935d38ce3 /* ofxTLAudioTrack.cpp in Sources */,
-				fb591e0c571e53b3ba5a60b84605de3d /* ofxTLBangs.cpp in Sources */,
-				cf54b41ab5ff1af0e8677338f5f60395 /* ofxTLCameraTrack.cpp in Sources */,
-				9d7bb9637658a8e9d507c66c47db010f /* ofxTLColors.cpp in Sources */,
-				49e60cc9bbcafb6eade107cc20884b9c /* ofxTLColorTrack.cpp in Sources */,
-				46be87fc2c481a1eb41aed2a8b97fe96 /* ofxTLCurves.cpp in Sources */,
-				4df88daf2c820a78327000e7ac0925c5 /* ofxTLEmptyKeyframes.cpp in Sources */,
-				98126aa8f306f3ee0f5f37bed7056435 /* ofxTLEmptyTrack.cpp in Sources */,
-				c3bc382653a57ce71d4513f1eaba414b /* ofxTLFlags.cpp in Sources */,
-				1479a06207a85dfdeca39f009ad023d0 /* ofxTLImageSequence.cpp in Sources */,
-				def58837140932f5996c61c2241ef66e /* ofxTLImageSequenceFrame.cpp in Sources */,
-				95e6e69db45e5f9e4f1c21e09d04b380 /* ofxTLImageTrack.cpp in Sources */,
-				d7058ecb9868a269655092911f63df8c /* ofxTLInOut.cpp in Sources */,
-				b3baa90667d4b61631ba59627d616a39 /* ofxTLKeyframes.cpp in Sources */,
-				e48c9224adc0eb481a762e226aaffadb /* ofxTLLFO.cpp in Sources */,
-				c7d250488914920c32f18f34136a2175 /* ofxTLPage.cpp in Sources */,
-				bcfdfc3681cf3552bcdb819e675b5dce /* ofxTLPageTabs.cpp in Sources */,
-				9e8ec2bf8bca13da057fa929463bbafb /* ofxTLSwitches.cpp in Sources */,
-				3a02cdf226d01ebb6533d47f0bb42c5a /* ofxTLTicker.cpp in Sources */,
-				f4a426f97ee8f1a3ead2a8f00212b48a /* ofxTLTrack.cpp in Sources */,
-				e6b21161287eea55fa4ea984beef0d72 /* ofxTLTrackHeader.cpp in Sources */,
-				65b24cd86db2ed8edd3385ac3e4a4783 /* ofxTLVideoThumb.cpp in Sources */,
-				3b32d3b612022d0c5b272bdd39e8a60f /* ofxTLVideoTrack.cpp in Sources */,
-				ed77da7c8d99d9b1c9c240c836f5baf7 /* ofxTLZoomer.cpp in Sources */,
-				d5f416a7f5798651d8370d5e93c0c797 /* kiss_fft.c in Sources */,
-				782c2b355cb6ebc83bdb95e0bd931001 /* kiss_fftr.c in Sources */,
-				168c43f69af6a8042ea0b13f08dfe5ff /* easing_terms_of_use.html in Sources */,
-				9266028e1aecbb027abf64d8cfab4b5f /* ofxEasing.cpp in Sources */,
-				5e0dbde5736deb3a5886b3f1e3b4578d /* ofxEasingBack.cpp in Sources */,
-				ead3ce0789481f975f351f39ee5137c4 /* ofxEasingBounce.cpp in Sources */,
-				27765d1bff26bd9a6186915f24dfd27c /* ofxEasingCirc.cpp in Sources */,
-				e816d7d242d315fb53e23f5443df8700 /* ofxEasingCubic.cpp in Sources */,
-				6e062274743f6716a9ad43959541a220 /* ofxEasingElastic.cpp in Sources */,
-				59eeacb88f062457ff86492c078803bd /* ofxEasingExpo.cpp in Sources */,
-				152eaecabd008d84af7f27f83f4389c4 /* ofxEasingLinear.cpp in Sources */,
-				6d7b53ed56654abbf2ff13b127236c33 /* ofxEasingQuad.cpp in Sources */,
-				85a41526fdfa1a8cdaee81f79de999b7 /* ofxEasingQuart.cpp in Sources */,
-				7e769097de6561633305b24c2ad560e7 /* ofxEasingQuint.cpp in Sources */,
-				fe278f5f783581237ae8ecb25ea719bb /* ofxEasingSine.cpp in Sources */,
-				32fc7731c1ef7b87e491c93d78c84b88 /* ofxTween.cpp in Sources */,
-				E7213A0016BCCDD60011637E /* ofOpenALSoundPlayer_TimelineAdditions.cpp in Sources */,
+				85F988D31AFCDE3300BA7587 /* ofxMSATimer.cpp in Sources */,
+				85F988B51AFCDE3200BA7587 /* ofxTLFlags.cpp in Sources */,
+				E4B69E210A3A1BDC003C02F2 /* ofApp.cpp in Sources */,
+				F6CA03081709FCBFDAEF6676 /* ofxTextInputField.cpp in Sources */,
+				85F988B81AFCDE3200BA7587 /* ofxTLImageTrack.cpp in Sources */,
+				6499B8489905BFE9067F8DB8 /* ofxTimecode.cpp in Sources */,
+				168C43F69AF6A8042EA0B13F /* easing_terms_of_use.html in Sources */,
+				85F988B11AFCDE3200BA7587 /* ofxTLColorTrack.cpp in Sources */,
+				9266028E1AECBB027ABF64D8 /* ofxEasing.cpp in Sources */,
+				85F988BB1AFCDE3200BA7587 /* ofxTLLFO.cpp in Sources */,
+				85F988B01AFCDE3200BA7587 /* ofxTLColors.cpp in Sources */,
+				5E0DBDE5736DEB3A5886B3F1 /* ofxEasingBack.cpp in Sources */,
+				85F988B91AFCDE3200BA7587 /* ofxTLInOut.cpp in Sources */,
+				85F988AA1AFCDE3200BA7587 /* ofxHotKeys_impl_win.cpp in Sources */,
+				EAD3CE0789481F975F351F39 /* ofxEasingBounce.cpp in Sources */,
+				27765D1BFF26BD9A6186915F /* ofxEasingCirc.cpp in Sources */,
+				85F988AE1AFCDE3200BA7587 /* ofxTLBangs.cpp in Sources */,
+				85F988AB1AFCDE3200BA7587 /* ofxRemoveCocoaMenu.mm in Sources */,
+				85F988B61AFCDE3200BA7587 /* ofxTLImageSequence.cpp in Sources */,
+				E816D7D242D315FB53E23F54 /* ofxEasingCubic.cpp in Sources */,
+				6E062274743F6716A9AD4395 /* ofxEasingElastic.cpp in Sources */,
+				85F988A91AFCDE3200BA7587 /* ofxHotKeys_impl_mac.mm in Sources */,
+				85F988B21AFCDE3200BA7587 /* ofxTLCurves.cpp in Sources */,
+				59EEACB88F062457FF86492C /* ofxEasingExpo.cpp in Sources */,
+				85F988AF1AFCDE3200BA7587 /* ofxTLCameraTrack.cpp in Sources */,
+				85F988A81AFCDE3200BA7587 /* ofxHotKeys_impl_linux.cpp in Sources */,
+				85F988B31AFCDE3200BA7587 /* ofxTLEmptyKeyframes.cpp in Sources */,
+				152EAECABD008D84AF7F27F8 /* ofxEasingLinear.cpp in Sources */,
+				6D7B53ED56654ABBF2FF13B1 /* ofxEasingQuad.cpp in Sources */,
+				85F988C51AFCDE3200BA7587 /* kiss_fft.c in Sources */,
+				85F988C41AFCDE3200BA7587 /* ofxTLZoomer.cpp in Sources */,
+				85F988B71AFCDE3200BA7587 /* ofxTLImageSequenceFrame.cpp in Sources */,
+				85F988B41AFCDE3200BA7587 /* ofxTLEmptyTrack.cpp in Sources */,
+				85A41526FDFA1A8CDAEE81F7 /* ofxEasingQuart.cpp in Sources */,
+				7E769097DE6561633305B24C /* ofxEasingQuint.cpp in Sources */,
+				85F988BD1AFCDE3200BA7587 /* ofxTLPageTabs.cpp in Sources */,
+				85F988C71AFCDE3200BA7587 /* ofOpenALSoundPlayer_TimelineAdditions.cpp in Sources */,
+				FE278F5F783581237AE8ECB2 /* ofxEasingSine.cpp in Sources */,
+				32FC7731C1EF7B87E491C93D /* ofxTween.cpp in Sources */,
+				85F988C31AFCDE3200BA7587 /* ofxTLVideoTrack.cpp in Sources */,
+				63B57AC5BF4EF088491E0317 /* ofxXmlSettings.cpp in Sources */,
+				85F988BA1AFCDE3200BA7587 /* ofxTLKeyframes.cpp in Sources */,
+				85F988BE1AFCDE3200BA7587 /* ofxTLSwitches.cpp in Sources */,
+				85F988C01AFCDE3200BA7587 /* ofxTLTrack.cpp in Sources */,
+				933A2227713C720CEFF80FD9 /* tinyxml.cpp in Sources */,
+				85F988C21AFCDE3200BA7587 /* ofxTLVideoThumb.cpp in Sources */,
+				85F988AD1AFCDE3200BA7587 /* ofxTLAudioTrack.cpp in Sources */,
+				85F988AC1AFCDE3200BA7587 /* ofxTimeline.cpp in Sources */,
+				9D44DC88EF9E7991B4A09951 /* tinyxmlerror.cpp in Sources */,
+				85F988C61AFCDE3200BA7587 /* kiss_fftr.c in Sources */,
+				5A4349E9754D6FA14C0F2A3A /* tinyxmlparser.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -837,7 +870,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E4EB6923138AFD0F00A09F29 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH)";
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/bin/";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -855,44 +888,29 @@
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(OF_CORE_HEADERS)",
-					../../../addons/ofxXmlSettings/libs,
-					../../../addons/ofxXmlSettings/src,
-					../../../addons/ofxMSATimer/libs,
-					../../../addons/ofxMSATimer/src,
 					../../../addons/ofxRange/libs,
 					../../../addons/ofxRange/src,
 					../../../addons/ofxTextInputField/libs,
 					../../../addons/ofxTextInputField/src,
 					../../../addons/ofxTimecode/libs,
 					../../../addons/ofxTimecode/src,
-					../../../addons/ofxTimeline/libs,
-					../../../addons/ofxTimeline/libs/kiss,
-					../../../addons/ofxTimeline/libs/kiss/include,
-					../../../addons/ofxTimeline/libs/kiss/lib,
-					../../../addons/ofxTimeline/libs/kiss/src,
-					../../../addons/ofxTimeline/libs/ofOpenALSoundPlayer_TimelineAdditions,
-					../../../addons/ofxTimeline/libs/sndfile,
-					../../../addons/ofxTimeline/libs/sndfile/include,
-					../../../addons/ofxTimeline/libs/sndfile/include/AL,
-					../../../addons/ofxTimeline/libs/sndfile/lib,
-					../../../addons/ofxTimeline/libs/sndfile/lib/osx,
-					../../../addons/ofxTimeline/libs/vorbis,
-					../../../addons/ofxTimeline/libs/vorbis/lib,
-					../../../addons/ofxTimeline/src,
 					../../../addons/ofxTween/libs,
 					../../../addons/ofxTween/src,
 					../../../addons/ofxTween/src/Easings,
+					../../../addons/ofxXmlSettings/libs,
+					../../../addons/ofxXmlSettings/src,
+					../../../addons/libs,
+					../../../addons/src,
+					src,
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D__MACOSX_CORE__",
 					"-lpthread",
 					"-mtune=native",
 				);
-				OTHER_LDFLAGS = (
-					"$(OF_CORE_LIBS)",
-					../../../addons/ofxTimeline/libs/sndfile/lib/osx/libsndfile.a,
-				);
-				SDKROOT = "";
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -900,7 +918,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E4EB6923138AFD0F00A09F29 /* Project.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH)";
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/bin/";
 				COPY_PHASE_STRIP = YES;
 				DEAD_CODE_STRIPPING = YES;
@@ -919,50 +937,35 @@
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(OF_CORE_HEADERS)",
-					../../../addons/ofxXmlSettings/libs,
-					../../../addons/ofxXmlSettings/src,
-					../../../addons/ofxMSATimer/libs,
-					../../../addons/ofxMSATimer/src,
 					../../../addons/ofxRange/libs,
 					../../../addons/ofxRange/src,
 					../../../addons/ofxTextInputField/libs,
 					../../../addons/ofxTextInputField/src,
 					../../../addons/ofxTimecode/libs,
 					../../../addons/ofxTimecode/src,
-					../../../addons/ofxTimeline/libs,
-					../../../addons/ofxTimeline/libs/kiss,
-					../../../addons/ofxTimeline/libs/kiss/include,
-					../../../addons/ofxTimeline/libs/kiss/lib,
-					../../../addons/ofxTimeline/libs/kiss/src,
-					../../../addons/ofxTimeline/libs/ofOpenALSoundPlayer_TimelineAdditions,
-					../../../addons/ofxTimeline/libs/sndfile,
-					../../../addons/ofxTimeline/libs/sndfile/include,
-					../../../addons/ofxTimeline/libs/sndfile/include/AL,
-					../../../addons/ofxTimeline/libs/sndfile/lib,
-					../../../addons/ofxTimeline/libs/sndfile/lib/osx,
-					../../../addons/ofxTimeline/libs/vorbis,
-					../../../addons/ofxTimeline/libs/vorbis/lib,
-					../../../addons/ofxTimeline/src,
 					../../../addons/ofxTween/libs,
 					../../../addons/ofxTween/src,
 					../../../addons/ofxTween/src/Easings,
+					../../../addons/ofxXmlSettings/libs,
+					../../../addons/ofxXmlSettings/src,
+					../../../addons/libs,
+					../../../addons/src,
+					src,
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D__MACOSX_CORE__",
 					"-lpthread",
 					"-mtune=native",
 				);
-				OTHER_LDFLAGS = (
-					"$(OF_CORE_LIBS)",
-					../../../addons/ofxTimeline/libs/sndfile/lib/osx/libsndfile.a,
-				);
-				SDKROOT = "";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 		E4B69B600A3A1757003C02F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -970,80 +973,24 @@
 				);
 				FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1 = "\"$(SRCROOT)/../../../libs/glut/lib/osx\"";
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_MODEL_TUNING = NONE;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(SYSTEM_LIBRARY_DIR)/Frameworks/Carbon.framework/Headers/Carbon.h";
-				GCC_PREPROCESSOR_DEFINITIONS = "TIMELINE_AUDIO_INCLUDED=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"TIMELINE_AUDIO_INCLUDED=1",
+					"TIMELINE_VIDEO_INCLUDED=1",
+				);
+				ICON = "$(ICON_NAME_DEBUG)";
+				ICON_FILE = "$(ICON_FILE_PATH)$(ICON)";
 				INFOPLIST_FILE = "openFrameworks-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_2)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_3)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_4)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_5)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_6)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_7)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_8)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_9)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_10)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_11)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_12)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_13)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_14)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_15)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_2)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_3)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_7)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_8)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_9)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_10)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_11)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_12)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_13)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_16)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_17)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_18)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_19)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_20)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_21)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_22)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_23)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_24)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_25)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_26)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_27)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_28)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_29)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_30)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_31)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_32)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_33)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_34)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_35)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_36)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_37)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_38)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_39)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_40)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_41)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_42)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_43)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_44)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_45)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_46)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_47)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_48)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_49)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_50)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_51)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_52)",
+					/Developer/openFrameworks/addons/ofxTimeline/libs/sndfile/lib/osx,
 				);
-				PREBINDING = NO;
-				PRODUCT_NAME = "example-allTracksDebug";
+				PRODUCT_NAME = "$(TARGET_NAME)Debug";
+				TIMELINE_AUDIO_INCLUDED = 1;
+				TIMELINE_VIDEO_INCLUDED = 1;
+				USER_HEADER_SEARCH_PATHS = "../libs/openal/include/ ../libs/kiss/include/ ../libs/sndfile/include/";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1051,86 +998,31 @@
 		E4B69B610A3A1757003C02F2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
 				);
 				FRAMEWORK_SEARCH_PATHS_QUOTED_FOR_TARGET_1 = "\"$(SRCROOT)/../../../libs/glut/lib/osx\"";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_MODEL_TUNING = NONE;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "$(SYSTEM_LIBRARY_DIR)/Frameworks/Carbon.framework/Headers/Carbon.h";
-				GCC_PREPROCESSOR_DEFINITIONS = "TIMELINE_AUDIO_INCLUDED=1";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"TIMELINE_AUDIO_INCLUDED=1",
+					"TIMELINE_VIDEO_INCLUDED=1",
+				);
+				ICON = "$(ICON_NAME_RELEASE)";
+				ICON_FILE = "$(ICON_FILE_PATH)$(ICON)";
 				INFOPLIST_FILE = "openFrameworks-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_1)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_2)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_3)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_4)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_5)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_6)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_7)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_8)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_9)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_10)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_11)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_12)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_13)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_14)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_15)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_2)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_1)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_3)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_7)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_8)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_9)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_10)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_11)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_12)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_13)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_16)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_17)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_18)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_19)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_20)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_21)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_22)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_23)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_24)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_25)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_26)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_27)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_28)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_29)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_30)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_31)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_32)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_33)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_34)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_35)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_36)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_37)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_38)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_39)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_40)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_41)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_42)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_43)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_44)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_45)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_46)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_47)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_48)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_49)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_50)",
-					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_51)",
+					/Developer/openFrameworks/addons/ofxTimeline/libs/sndfile/lib/osx,
 				);
-				PREBINDING = NO;
-				PRODUCT_NAME = "example-allTracks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TIMELINE_AUDIO_INCLUDED = 1;
+				TIMELINE_VIDEO_INCLUDED = 1;
+				USER_HEADER_SEARCH_PATHS = "../libs/openal/include/ ../libs/kiss/include/ ../libs/sndfile/include/";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/example-allTracks/example-allTracks.xcodeproj/xcshareddata/xcschemes/example-allTracks Debug.xcscheme
+++ b/example-allTracks/example-allTracks.xcodeproj/xcshareddata/xcschemes/example-allTracks Debug.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+               BuildableName = "example-allTracks.app"
+               BlueprintName = "example-allTracks"
+               ReferencedContainer = "container:example-allTracks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+            BuildableName = "example-allTracks.app"
+            BlueprintName = "example-allTracks"
+            ReferencedContainer = "container:example-allTracks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+            BuildableName = "example-allTracks.app"
+            BlueprintName = "example-allTracks"
+            ReferencedContainer = "container:example-allTracks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+            BuildableName = "example-allTracks.app"
+            BlueprintName = "example-allTracks"
+            ReferencedContainer = "container:example-allTracks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/example-allTracks/example-allTracks.xcodeproj/xcshareddata/xcschemes/example-allTracks Release.xcscheme
+++ b/example-allTracks/example-allTracks.xcodeproj/xcshareddata/xcschemes/example-allTracks Release.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+               BuildableName = "example-allTracks.app"
+               BlueprintName = "example-allTracks"
+               ReferencedContainer = "container:example-allTracks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Release">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+            BuildableName = "example-allTracks.app"
+            BlueprintName = "example-allTracks"
+            ReferencedContainer = "container:example-allTracks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+            BuildableName = "example-allTracks.app"
+            BlueprintName = "example-allTracks"
+            ReferencedContainer = "container:example-allTracks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E4B69B5A0A3A1756003C02F2"
+            BuildableName = "example-allTracks.app"
+            BlueprintName = "example-allTracks"
+            ReferencedContainer = "container:example-allTracks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/example-allTracks/openFrameworks-Info.plist
+++ b/example-allTracks/openFrameworks-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.openFrameworks</string>
+	<string>cc.openFrameworks.ofapp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
@@ -16,5 +16,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>CFBundleIconFile</key>
+	<string>${ICON}</string>
 </dict>
 </plist>

--- a/example-allTracks/src/main.cpp
+++ b/example-allTracks/src/main.cpp
@@ -1,5 +1,5 @@
 #include "ofMain.h"
-#include "testApp.h"
+#include "ofApp.h"
 #include "ofAppGlutWindow.h"
 
 //========================================================================
@@ -7,10 +7,11 @@ int main( ){
 
     ofAppGlutWindow window;
 	ofSetupOpenGL(&window, 850,768, OF_WINDOW);			// <-------- setup the GL context
+	//ofSetupOpenGL(850,768, OF_WINDOW);			// <-------- setup the GL context
 
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:
-	ofRunApp( new testApp());
+	ofRunApp( new ofApp());
 
 }

--- a/example-allTracks/src/ofApp.cpp
+++ b/example-allTracks/src/ofApp.cpp
@@ -1,7 +1,7 @@
-#include "testApp.h"
+#include "ofApp.h"
 
 //--------------------------------------------------------------
-void testApp::setup(){
+void ofApp::setup(){
 	
     ofBackground(255*.15);
     ofSetVerticalSync(true);
@@ -9,8 +9,9 @@ void testApp::setup(){
 
     ofxTimeline::removeCocoaMenusFromGlut("AllTracksExample");
 	timeline.setup();
-
+  #ifdef TIMELINE_VIDEO_INCLUDED
 	timeline.addVideoTrack("fingers", "fingers.mov");
+  #endif
   #ifdef TIMELINE_AUDIO_INCLUDED
     timeline.addAudioTrack("audio", "4chan.wav");
     timeline.setDurationInSeconds(timeline.getAudioTrack("audio")->getDuration());
@@ -32,21 +33,21 @@ void testApp::setup(){
 	timeline.enableSnapToOtherKeyframes(false);
 	timeline.setLoopType(OF_LOOP_NORMAL);
 	
-	ofAddListener(timeline.events().bangFired, this, &testApp::bangFired);
+	ofAddListener(timeline.events().bangFired, this, &ofApp::bangFired);
 }
 
 //--------------------------------------------------------------
-void testApp::bangFired(ofxTLBangEventArgs& args){
+void ofApp::bangFired(ofxTLBangEventArgs& args){
 	cout << "bang fired!" << args.flag << endl;
 }
 
 //--------------------------------------------------------------
-void testApp::update(){
+void ofApp::update(){
 
 }
 
 //--------------------------------------------------------------
-void testApp::draw(){
+void ofApp::draw(){
 	if(timeline.isSwitchOn("switches")){
 		ofBackground(timeline.getColor("colors"));
 	}
@@ -57,46 +58,46 @@ void testApp::draw(){
 }
 
 //--------------------------------------------------------------
-void testApp::keyPressed(int key){
+void ofApp::keyPressed(int key){
     
 }
 
 //--------------------------------------------------------------
-void testApp::keyReleased(int key){
+void ofApp::keyReleased(int key){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mouseMoved(int x, int y ){
+void ofApp::mouseMoved(int x, int y ){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mouseDragged(int x, int y, int button){
+void ofApp::mouseDragged(int x, int y, int button){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mousePressed(int x, int y, int button){
+void ofApp::mousePressed(int x, int y, int button){
 
 }
 
 //--------------------------------------------------------------
-void testApp::mouseReleased(int x, int y, int button){
+void ofApp::mouseReleased(int x, int y, int button){
 
 }
 
 //--------------------------------------------------------------
-void testApp::windowResized(int w, int h){
+void ofApp::windowResized(int w, int h){
 
 }
 
 //--------------------------------------------------------------
-void testApp::gotMessage(ofMessage msg){
+void ofApp::gotMessage(ofMessage msg){
 
 }
 
 //--------------------------------------------------------------
-void testApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){ 
 
 }

--- a/example-allTracks/src/ofApp.h
+++ b/example-allTracks/src/ofApp.h
@@ -3,7 +3,7 @@
 #include "ofMain.h"
 #include "ofxTimeline.h"
 
-class testApp : public ofBaseApp{
+class ofApp : public ofBaseApp{
 
 	public:
 		void setup();

--- a/libs/ofOpenALSoundPlayer_TimelineAdditions/src/ofOpenALSoundPlayer_TimelineAdditions.cpp
+++ b/libs/ofOpenALSoundPlayer_TimelineAdditions/src/ofOpenALSoundPlayer_TimelineAdditions.cpp
@@ -56,7 +56,7 @@ ofOpenALSoundPlayer_TimelineAdditions::ofOpenALSoundPlayer_TimelineAdditions(){
 
 // ----------------------------------------------------------------------------
 ofOpenALSoundPlayer_TimelineAdditions::~ofOpenALSoundPlayer_TimelineAdditions(){
-	unloadSound();
+	unload();
 	kiss_fftr_free(fftCfg);
 	players.erase(this);
 }
@@ -347,7 +347,7 @@ void ofOpenALSoundPlayer_TimelineAdditions::readFile(string fileName, vector<sho
 }
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer_TimelineAdditions::loadSound(string fileName, bool is_stream){
+bool ofOpenALSoundPlayer_TimelineAdditions::load(string fileName, bool is_stream){
 
     string ext = ofToLower(ofFilePath::getFileExt(fileName));
     if(ext != "wav" && ext != "aif" && ext != "aiff"){
@@ -368,7 +368,7 @@ bool ofOpenALSoundPlayer_TimelineAdditions::loadSound(string fileName, bool is_s
 	// & prevent user-created memory leaks
 	// if they call "loadSound" repeatedly, for example
 
-	unloadSound();
+	unload();
 
 	ALenum format=AL_FORMAT_MONO16;
 
@@ -552,7 +552,7 @@ void ofOpenALSoundPlayer_TimelineAdditions::update(ofEventArgs & args){
 }
 
 //------------------------------------------------------------
-void ofOpenALSoundPlayer_TimelineAdditions::unloadSound(){
+void ofOpenALSoundPlayer_TimelineAdditions::unload(){
     
 //	ofRemoveListener(ofEvents.update,this,&ofOpenALSoundPlayer_TimelineAdditions::update);
 	if(isLoaded()){
@@ -567,7 +567,7 @@ void ofOpenALSoundPlayer_TimelineAdditions::unloadSound(){
 }
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer_TimelineAdditions::getIsPlaying(){
+bool ofOpenALSoundPlayer_TimelineAdditions::isPlaying() const{
 	if(sources.empty()) return false;
 	if(isStreaming) return isThreadRunning();
 	ALint state;
@@ -592,12 +592,12 @@ bool ofOpenALSoundPlayer_TimelineAdditions::getIsPaused(){
 }
 
 //------------------------------------------------------------
-float ofOpenALSoundPlayer_TimelineAdditions::getSpeed(){
+float ofOpenALSoundPlayer_TimelineAdditions::getSpeed() const{
 	return speed;
 }
 
 //------------------------------------------------------------
-float ofOpenALSoundPlayer_TimelineAdditions::getPan(){
+float ofOpenALSoundPlayer_TimelineAdditions::getPan() const{
 	return pan;
 }
 
@@ -626,12 +626,12 @@ void ofOpenALSoundPlayer_TimelineAdditions::setVolume(float vol){
 }
 
 //------------------------------------------------------------
-float ofOpenALSoundPlayer_TimelineAdditions::getVolume(){
+float ofOpenALSoundPlayer_TimelineAdditions::getVolume() const{
 	return volume;    
 }
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer_TimelineAdditions::isLoaded(){
+bool ofOpenALSoundPlayer_TimelineAdditions::isLoaded() const{
     return bLoadedOk;
 }
 
@@ -663,7 +663,7 @@ void ofOpenALSoundPlayer_TimelineAdditions::setPositionMS(int ms){
 }
 
 //------------------------------------------------------------
-float ofOpenALSoundPlayer_TimelineAdditions::getPosition(){
+float ofOpenALSoundPlayer_TimelineAdditions::getPosition() const{
 	if(duration==0) return 0;
 	if(sources.empty()) return 0;
 	float pos;
@@ -686,7 +686,7 @@ float ofOpenALSoundPlayer_TimelineAdditions::getPosition(){
 }
 
 //------------------------------------------------------------
-int ofOpenALSoundPlayer_TimelineAdditions::getPositionMS(){
+int ofOpenALSoundPlayer_TimelineAdditions::getPositionMS() const{
 	if(duration==0) return 0;
 	if(sources.empty()) return 0;
 	int pos;
@@ -1043,7 +1043,7 @@ float * ofOpenALSoundPlayer_TimelineAdditions::getSystemSpectrum(int bands){
 
 	set<ofOpenALSoundPlayer_TimelineAdditions*>::iterator it;
 	for(it=players.begin();it!=players.end();it++){
-		if(!(*it)->getIsPlaying()) continue;
+		if(!(*it)->isPlaying()) continue;
 		float * buffer = (*it)->getCurrentBufferSum(signalSize);
 		for(int i=0;i<signalSize;i++){
 			systemWindowedSignal[i]+=buffer[i];

--- a/libs/ofOpenALSoundPlayer_TimelineAdditions/src/ofOpenALSoundPlayer_TimelineAdditions.h
+++ b/libs/ofOpenALSoundPlayer_TimelineAdditions/src/ofOpenALSoundPlayer_TimelineAdditions.h
@@ -73,8 +73,8 @@ class ofOpenALSoundPlayer_TimelineAdditions : public ofBaseSoundPlayer, public o
 		ofOpenALSoundPlayer_TimelineAdditions();
 		virtual ~ofOpenALSoundPlayer_TimelineAdditions();
 
-		bool loadSound(string fileName, bool stream = false);
-		void unloadSound();
+		bool load(string fileName, bool stream = false);
+		void unload();
 		void play();
 		void stop();
 
@@ -86,14 +86,14 @@ class ofOpenALSoundPlayer_TimelineAdditions : public ofBaseSoundPlayer, public o
 		void setMultiPlay(bool bMp);
 		void setPosition(float pct); // 0 = start, 1 = end;
 	    void setPositionMS(int ms);
-    
-		float getPosition();
-	    int getPositionMS();
-		bool getIsPlaying();
-		float getSpeed();
-		float getPan();
-	    float getVolume();
-	    bool isLoaded();
+	
+		float getPosition() const;
+		int getPositionMS() const;
+		bool isPlaying() const;
+		float getSpeed() const;
+		float getPan() const;
+		bool isLoaded() const;
+		float getVolume() const;
 		bool getIsPaused();
 		float getDuration();
 		int getNumChannels();

--- a/src/ofxTLAudioTrack.cpp
+++ b/src/ofxTLAudioTrack.cpp
@@ -49,7 +49,7 @@ ofxTLAudioTrack::~ofxTLAudioTrack(){
 
 bool ofxTLAudioTrack::loadSoundfile(string filepath){
 	soundLoaded = false;
-	if(player.loadSound(filepath, false)){
+	if(player.load(filepath, false)){
     	soundLoaded = true;
 		soundFilePath = filepath;
 		shouldRecomputePreview = true;
@@ -271,7 +271,7 @@ void ofxTLAudioTrack::boundsChanged(ofEventArgs& args){
 
 void ofxTLAudioTrack::play(){
 
-	if(!player.getIsPlaying()){
+	if(!player.isPlaying()){
         
 //		lastPercent = MIN(timeline->getPercentComplete() * timeline->getDurationInSeconds() / player.getDuration(), 1.0);
 		player.setLoop(timeline->getLoopType() == OF_LOOP_NORMAL);
@@ -291,7 +291,7 @@ void ofxTLAudioTrack::play(){
 }
 
 void ofxTLAudioTrack::stop(){
-	if(player.getIsPlaying()){
+	if(player.isPlaying()){
 		
 		player.setPaused(true);
 
@@ -316,7 +316,7 @@ void ofxTLAudioTrack::playbackStarted(ofxTLPlaybackEventArgs& args){
 
 void ofxTLAudioTrack::playbackLooped(ofxTLPlaybackEventArgs& args){
 	if(isSoundLoaded() && this != timeline->getTimecontrolTrack()){
-		if(!player.getIsPlaying()){
+		if(!player.isPlaying()){
 			player.play();
 		}
 		player.setPosition( positionForSecond(timeline->getCurrentTime()) );
@@ -340,7 +340,7 @@ bool ofxTLAudioTrack::togglePlay(){
 }
 
 bool ofxTLAudioTrack::getIsPlaying(){
-    return player.getIsPlaying();
+    return player.isPlaying();
 }
 
 void ofxTLAudioTrack::setSpeed(float speed){

--- a/src/ofxTLColorTrack.cpp
+++ b/src/ofxTLColorTrack.cpp
@@ -195,7 +195,7 @@ void ofxTLColorTrack::drawModalContent(){
 }
 
 void ofxTLColorTrack::loadColorPalette(ofBaseHasPixels& image){
-	colorPallete.setFromPixels(image.getPixelsRef());
+	colorPallete.setFromPixels(image.getPixels());
 	refreshAllSamples();
 }
 


### PR DESCRIPTION
Renames old ofBaseSound methods to the new ones. (OF 0.8)
( `loadSound()` becomes `load()`, etc. )